### PR TITLE
[VTEN-1] Support SVD and Batched SVD

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,25 @@ VTensor, a C++ library, facilitates tensor manipulation on GPUs, emulating the p
 It leverages RMM (RAPIDS Memory Manager) for efficient device memory management. 
 The library integrates CuRand, CuBLAS, and CuSolver to support a wide range of operations, including mathematics, linear algebra, and random number generation.
 Please visit our website https://vorticity-inc.github.io/VTensor/ for more information!
+
+## Test
+```sh
+bazel test ...
+```
+
+## Formatter
+```sh
+find lib  -name '*.hpp' |  xargs clang-format -i -style=file:clang.yaml 
+```
+
+## Update docs
+```sh
+doxygen docs/Doxyfile.in
+sphinx-build -b html docs/source docs/build/html
+```
+
+## Future updates
+- Support Solvers (Cholesky, QR etc.)
+- Support GPUDirect
+- Support more matrix operations
+- Support Sparse martix with CuSparse

--- a/README.md
+++ b/README.md
@@ -5,23 +5,23 @@ It leverages RMM (RAPIDS Memory Manager) for efficient device memory management.
 The library integrates CuRand, CuBLAS, and CuSolver to support a wide range of operations, including mathematics, linear algebra, and random number generation.
 Please visit our website https://vorticity-inc.github.io/VTensor/ for more information!
 
-## Test
+### Test
 ```sh
 bazel test ...
 ```
 
-## Formatter
+### Formatter
 ```sh
 find lib  -name '*.hpp' |  xargs clang-format -i -style=file:clang.yaml 
 ```
 
-## Update docs
+### Update docs
 ```sh
 doxygen docs/Doxyfile.in
 sphinx-build -b html docs/source docs/build/html
 ```
 
-## Future updates
+### Future updates
 - Support Solvers (Cholesky, QR etc.)
 - Support GPUDirect
 - Support more matrix operations

--- a/clang.yaml
+++ b/clang.yaml
@@ -1,0 +1,11 @@
+
+---
+BasedOnStyle:  Google
+IndentWidth: 4
+---
+Language:        Cpp
+DerivePointerAlignment: false
+PointerAlignment: Left
+AlignTrailingComments: true
+ColumnLimit:     160
+...

--- a/docs/source/api/linalg/index.rst
+++ b/docs/source/api/linalg/index.rst
@@ -9,3 +9,4 @@ Linear Algebra
    inv
    matmul
    product
+   svd

--- a/docs/source/api/linalg/svd.rst
+++ b/docs/source/api/linalg/svd.rst
@@ -1,0 +1,8 @@
+vt::linalg::svd
+=======================
+
+.. toctree::
+   :maxdepth: 1
+
+.. doxygenfunction:: vt::linalg::svd(Tensor<T, 2>& tensor, bool full_matrices = true, bool compute_uv = true, cusolverDnHandle_t handle = cuda::cusolver.get_handle())
+.. doxygenfunction:: vt::linalg::svd(Tensor<T, N>& tensor, bool full_matrices = true, bool compute_uv = true, cusolverDnHandle_t handle = cuda::cusolver.get_handle())

--- a/lib/core/cutensor.hpp
+++ b/lib/core/cutensor.hpp
@@ -21,19 +21,19 @@ class CuTensor {
      * @param tensor: The tensor to be adapted.
      */
     __host__ CuTensor(Tensor<T, N> tensor)
-        : CuTensor(tensor.raw_ptr(), tensor.shape().data(), tensor.strides().data(), tensor.start(), tensor.size(), tensor.sliced()) {}
+        : CuTensor(tensor.raw_ptr(), tensor.shape().data(), tensor.strides().data(), tensor.start(), tensor.size(), tensor.contiguous()) {}
 
     /**
-     * @brief Construct a new CuTensor object from a raw pointer, shape, strides, start index, and sliced flag.
+     * @brief Construct a new CuTensor object from a raw pointer, shape, strides, start index, and contiguous flag.
      *
      * @param data: The raw pointer to the data.
      * @param shape: The shape of the tensor.
      * @param strides: The strides of the tensor.
      * @param start: The start index of the tensor.
-     * @param sliced: The sliced flag of the tensor.
+     * @param contiguous: The contiguous flag of the tensor.
      */
-    __host__ __device__ CuTensor(T* data, const size_t* shape, const size_t* strides, const size_t start, const size_t size, const bool sliced)
-        : data(data), start(start), size(size), sliced(sliced) {
+    __host__ __device__ CuTensor(T* data, const size_t* shape, const size_t* strides, const size_t start, const size_t size, const bool contiguous)
+        : data(data), start(start), size(size), contiguous(contiguous) {
         for (size_t i = 0; i < N; ++i) {
             this->shape[i] = shape[i];
             this->strides[i] = strides[i];
@@ -86,7 +86,7 @@ class CuTensor {
      * @param n: The 1D index of the tensor.
      * @return T: The data of the tensor.
      */
-    __host__ __device__ T& operator[](size_t n) { return !sliced ? data[n] : data[get_iterator_index<N>(n, shape, strides, start)]; }
+    __host__ __device__ T& operator[](size_t n) { return contiguous ? data[n] : data[get_iterator_index<N>(n, shape, strides, start)]; }
 
     /**
      * @brief Return the data given the iterative index
@@ -94,13 +94,13 @@ class CuTensor {
      * @param n: The 1D index of the tensor.
      * @return T: The data of the tensor.
      */
-    __host__ __device__ const T& operator[](size_t n) const { return !sliced ? data[n] : data[get_iterator_index<N>(n, shape, strides, start)]; }
+    __host__ __device__ const T& operator[](size_t n) const { return contiguous ? data[n] : data[get_iterator_index<N>(n, shape, strides, start)]; }
 
     size_t shape[N];
     size_t strides[N];
     size_t start;
     size_t size = 0;
-    bool sliced;
+    bool contiguous;
     T* data;
 };
 

--- a/lib/core/iterator.hpp
+++ b/lib/core/iterator.hpp
@@ -42,10 +42,10 @@ class TensorIterator : public thrust::iterator_adaptor<TensorIterator<Iterator, 
      * @param shape: The shape of the tensor.
      * @param strides: The strides of the tensor.
      * @param start: The start index of the tensor.
-     * @param sliced: The sliced flag of the tensor.
+     * @param contiguous: The contiguous flag of the tensor.
      */
-    __host__ __device__ TensorIterator(const Iterator& iter, const size_t* shape, const size_t* strides, const size_t start, const bool sliced)
-        : thrust::iterator_adaptor<TensorIterator<Iterator, N>, Iterator>(iter), start(start), sliced(sliced) {
+    __host__ __device__ TensorIterator(const Iterator& iter, const size_t* shape, const size_t* strides, const size_t start, const bool contiguous)
+        : thrust::iterator_adaptor<TensorIterator<Iterator, N>, Iterator>(iter), start(start), contiguous(contiguous) {
         for (size_t i = 0; i < N; ++i) {
             this->shape[i] = shape[i];
             this->strides[i] = strides[i];
@@ -54,11 +54,11 @@ class TensorIterator : public thrust::iterator_adaptor<TensorIterator<Iterator, 
 
     /**
      * @brief Advance the iterator by n steps.
-     * If the iterator is not sliced, used the default advance method, otherwise calculate the new index based on the strides and shape.
+     * If the iterator is contiguous, used the default advance method, otherwise calculate the new index based on the strides and shape.
      * @param n: Number of steps.
      */
     __host__ __device__ void advance(typename thrust::iterator_difference<Iterator>::type n) {
-        if (!sliced) {
+        if (contiguous) {
             this->base_reference() += n;
         } else {
             this->base_reference() += get_iterator_index<N>(n, shape, strides, start);
@@ -69,7 +69,7 @@ class TensorIterator : public thrust::iterator_adaptor<TensorIterator<Iterator, 
     size_t shape[N];
     size_t strides[N];
     size_t start;
-    bool sliced;
+    bool contiguous;
 };
 
 }  // namespace vt

--- a/lib/core/slice.hpp
+++ b/lib/core/slice.hpp
@@ -17,6 +17,9 @@ class Slice {
     size_t end;
     size_t step;
 
+    // Default constructor
+    Slice() = default;
+
     /**
      * @brief Construct a new Slice object
      *

--- a/lib/core/tests/test_slice.cc
+++ b/lib/core/tests/test_slice.cc
@@ -24,8 +24,8 @@ TEST(Slice1DTensor, BasicAssertions) {
     auto tensor1 = tensor({1, 10, 2});
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 3, 5, 7, 9}));
-    EXPECT_EQ(tensor.sliced(), false);
-    EXPECT_EQ(tensor1.sliced(), true);
+    EXPECT_EQ(tensor.contiguous(), true);
+    EXPECT_EQ(tensor1.contiguous(), false);
     EXPECT_EQ(tensor1.size(), 5);
 }
 
@@ -34,8 +34,8 @@ TEST(Slice2DTensor, BasicAssertions) {
     auto tensor1 = tensor({1, 3, 1}, {0, 3, 2});
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{3, 5, 6, 8}));
-    EXPECT_EQ(tensor.sliced(), false);
-    EXPECT_EQ(tensor1.sliced(), true);
+    EXPECT_EQ(tensor.contiguous(), true);
+    EXPECT_EQ(tensor1.contiguous(), false);
     EXPECT_EQ(tensor1.size(), 4);
 }
 
@@ -47,9 +47,9 @@ TEST(SliceAndAssigmentFromTensor, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 3, 1, 5, 6, 1, 8, 1, 1, 1}));
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
     EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{3, 5, 6, 8}));
-    EXPECT_EQ(tensor1.sliced(), false);
-    EXPECT_EQ(tensor2.sliced(), false);
-    EXPECT_EQ(tensor3.sliced(), true);
+    EXPECT_EQ(tensor1.contiguous(), true);
+    EXPECT_EQ(tensor2.contiguous(), true);
+    EXPECT_EQ(tensor3.contiguous(), false);
     EXPECT_EQ(tensor3.size(), 4);
 }
 
@@ -59,13 +59,13 @@ TEST(SliceAndAssigmentFromProxy, BasicAssertions) {
     tensor1({1, 3, 1}, {0, 3, 2}) = tensor2({1, 3, 1}, {0, 3, 2});
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 3, 1, 5, 6, 1, 8, 1, 1, 1}));
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
-    EXPECT_EQ(tensor1.sliced(), false);
-    EXPECT_EQ(tensor2.sliced(), false);
+    EXPECT_EQ(tensor1.contiguous(), true);
+    EXPECT_EQ(tensor2.contiguous(), true);
 }
 
 TEST(SliceAndAssigmentFromConstant, BasicAssertions) {
     auto tensor1 = vt::ones(4, 3);
     tensor1({1, 3, 1}, {0, 3, 2}) = 2;
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 2, 1, 2, 2, 1, 2, 1, 1, 1}));
-    EXPECT_EQ(tensor1.sliced(), false);
+    EXPECT_EQ(tensor1.contiguous(), true);
 }

--- a/lib/core/tests/test_tensor.cc
+++ b/lib/core/tests/test_tensor.cc
@@ -21,7 +21,7 @@ TEST(TensorConstructor, BasicAssertions) {
     EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{1, 2, 3}));
     EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{6, 3, 1}));
     EXPECT_EQ(tensor.start(), 0);
-    EXPECT_EQ(tensor.sliced(), false);
+    EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 0, 0, 0, 0, 0}));
 
     vector_type data(6, 1);
@@ -30,7 +30,7 @@ TEST(TensorConstructor, BasicAssertions) {
     EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{1, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{6, 3, 1}));
     EXPECT_EQ(tensor1.start(), 0);
-    EXPECT_EQ(tensor1.sliced(), false);
+    EXPECT_EQ(tensor1.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 1, 1, 1}));
 
     auto shape2 = std::array<size_t, 1>{5};
@@ -40,7 +40,7 @@ TEST(TensorConstructor, BasicAssertions) {
     EXPECT_EQ(tensor2.shape(), (std::array<size_t, 1>{5}));
     EXPECT_EQ(tensor2.strides(), (std::array<size_t, 1>{1}));
     EXPECT_EQ(tensor2.start(), 1);
-    EXPECT_EQ(tensor2.sliced(), true);
+    EXPECT_EQ(tensor2.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{1, 1, 1, 1, 1}));
 }
 
@@ -50,7 +50,7 @@ TEST(TensorReshape, BasicAssertions) {
     EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{1, 2, 3}));
     EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{6, 3, 1}));
     EXPECT_EQ(tensor.start(), 0);
-    EXPECT_EQ(tensor.sliced(), false);
+    EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5}));
 }
 
@@ -61,7 +61,7 @@ TEST(SlicedTensorReshape, BasicAssertions) {
     EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{1, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{6, 3, 1}));
     EXPECT_EQ(tensor1.start(), 0);
-    EXPECT_EQ(tensor1.sliced(), false);
+    EXPECT_EQ(tensor1.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10}));
 }
 
@@ -115,6 +115,10 @@ TEST(TensorSliceOperation, BasicAssertions) {
     auto tensor3 = vt::zeros(vt::Shape<3>{2, 2, 2});
     tensor3(vt::Slice(0, 2, 1), vt::Slice(0, 2, 1), vt::Slice(0, 2, 1));
     tensor3({0, 2, 1}, {0, 2, 1}, {0, 2, 1});
+
+    auto tensor4 = vt::zeros(vt::Shape<3>{2, 2, 2});
+    std::array<vt::Slice, 3> slices = {vt::Slice(0, 2, 1), vt::Slice(0, 2, 1), vt::Slice(0, 2, 1)};
+    tensor4(slices);
 }
 
 TEST(TensorSliceAlongTheAxisOperation, BasicAssertions) {
@@ -132,5 +136,5 @@ TEST(TensorApplySlices, BasicAssertions) {
     EXPECT_EQ(tensor2.shape(), (std::array<size_t, 1>{6}));
     EXPECT_EQ(tensor2.strides(), (std::array<size_t, 1>{2}));
     EXPECT_EQ(tensor2.start(), 0);
-    EXPECT_EQ(tensor2.sliced(), true);
+    EXPECT_EQ(tensor2.contiguous(), false);
 }

--- a/lib/linalg/BUILD
+++ b/lib/linalg/BUILD
@@ -9,6 +9,7 @@ cuda_library(
         "inv.hpp",
         "matmul.hpp",
         "product.hpp",
+        "svd.hpp",
     ],
     deps = [
         "//lib/core:core",

--- a/lib/linalg/cusolver.hpp
+++ b/lib/linalg/cusolver.hpp
@@ -91,6 +91,12 @@ struct CuSolverFuncType {
     using GetRFT = cusolverStatus_t (*)(cusolverDnHandle_t, int, int, T*, int, T*, int*, int*);
     using GetRST = cusolverStatus_t (*)(cusolverDnHandle_t, cublasOperation_t, int, int, const T*, int, const int*, T*, int, int*);
     using GetRFBufferSizeT = cusolverStatus_t (*)(cusolverDnHandle_t, int, int, T*, int, int*);
+    using GeSVDT = cusolverStatus_t (*)(cusolverDnHandle_t, signed char, signed char, int, int, T*, int, T*, T*, int, T*, int, T*, int, T*, int*);
+    using GeSVDBufferSizeT = cusolverStatus_t (*)(cusolverDnHandle_t, int, int, int*);
+    using GeSVDJBatchedT = cusolverStatus_t (*)(cusolverDnHandle_t, cusolverEigMode_t, int, int, T*, int, T*, T*, int, T*, int, T*, int, int*, gesvdjInfo_t,
+                                                int);
+    using GeSVDJBatchedBufferSizeT = cusolverStatus_t (*)(cusolverDnHandle_t, cusolverEigMode_t, int, int, const T*, int, const T*, const T*, int, const T*,
+                                                          int, int*, gesvdjInfo_t, int);
 };
 
 /**
@@ -109,6 +115,10 @@ struct CuSolverFunc<float> {
     static constexpr CuSolverFuncType<float>::GetRFT getrf() { return cusolverDnSgetrf; }
     static constexpr CuSolverFuncType<float>::GetRST getrs() { return cusolverDnSgetrs; }
     static constexpr CuSolverFuncType<float>::GetRFBufferSizeT getrf_buffer_size() { return cusolverDnSgetrf_bufferSize; }
+    static constexpr CuSolverFuncType<float>::GeSVDT gesvd() { return cusolverDnSgesvd; }
+    static constexpr CuSolverFuncType<float>::GeSVDBufferSizeT gesvd_buffer_size() { return cusolverDnSgesvd_bufferSize; }
+    static constexpr CuSolverFuncType<float>::GeSVDJBatchedT gesvdj_batched() { return cusolverDnSgesvdjBatched; }
+    static constexpr CuSolverFuncType<float>::GeSVDJBatchedBufferSizeT gesvdj_batched_buffer_size() { return cusolverDnSgesvdjBatched_bufferSize; }
 };
 
 /**
@@ -119,6 +129,10 @@ struct CuSolverFunc<double> {
     static constexpr CuSolverFuncType<double>::GetRFT getrf() { return cusolverDnDgetrf; }
     static constexpr CuSolverFuncType<double>::GetRST getrs() { return cusolverDnDgetrs; }
     static constexpr CuSolverFuncType<double>::GetRFBufferSizeT getrf_buffer_size() { return cusolverDnDgetrf_bufferSize; }
+    static constexpr CuSolverFuncType<double>::GeSVDT gesvd() { return cusolverDnDgesvd; }
+    static constexpr CuSolverFuncType<double>::GeSVDBufferSizeT gesvd_buffer_size() { return cusolverDnDgesvd_bufferSize; }
+    static constexpr CuSolverFuncType<double>::GeSVDJBatchedT gesvdj_batched() { return cusolverDnDgesvdjBatched; }
+    static constexpr CuSolverFuncType<double>::GeSVDJBatchedBufferSizeT gesvdj_batched_buffer_size() { return cusolverDnDgesvdjBatched_bufferSize; }
 };
 
 }  // namespace cuda

--- a/lib/linalg/svd.hpp
+++ b/lib/linalg/svd.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <lib/core/tensor.hpp>
+#include <lib/generator/eye.hpp>
+#include <lib/generator/zeros.hpp>
+#include <lib/linalg/cublas.hpp>
+#include <lib/linalg/cusolver.hpp>
+#include <lib/memory/copy.hpp>
+#include <tuple>
+
+namespace vt {
+
+namespace linalg {
+
+/**
+ * @brief Singular Value Decomposition.
+ *
+ * @tparam T: Data type of the tensor.
+ * @param tensor: The tensor object to be decomposed.
+ * @param full_matrices: If True, it returns u and v with full dimensions.
+ * @param compute_uv: If False, it only returns singular values.
+ * @param handle: The CuSolver handle. The default is the global CuSolver handle.
+ * @return A tuple of U, S, V, where tensor = U * diag(S) * V. (diag neeeded to be implemented)
+ */
+template <typename T>
+std::tuple<Tensor<T, 2>, Tensor<T, 1>, Tensor<T, 2>> svd(Tensor<T, 2>& tensor, bool full_matrices = true, bool compute_uv = true,
+                                                         cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+    auto [n, m] = tensor.shape();
+    Tensor<T, 2> x;
+    bool trans_flag;
+
+    // CuSolver only supports m >= n for SVD. If m < n, we need to transpose the tensor.
+    if (m >= n) {
+        x = copy(tensor);
+        trans_flag = false;
+    } else {
+        x = copy(transpose(tensor));
+        std::swap(n, m);
+        trans_flag = true;
+    }
+
+    // Caculate the buffer size
+    int buffer_size;
+    auto helper = cuda::CuSolverFunc<T>::gesvd_buffer_size();
+    cuda::check_cusolver_status(helper(handle, m, n, &buffer_size), "Failed to get buffer size");
+    auto buffer = zeros<T>(buffer_size);
+
+    // Initialize U and VT
+    Tensor<T, 2> u;
+    Tensor<T, 2> vt;
+
+    signed char job_u;
+    signed char job_vt;
+
+    T* u_ptr;
+    T* vt_ptr;
+
+    if (compute_uv) {
+        if (full_matrices) {
+            u = zeros<T>(m, m);
+            vt = x({0, n}, {0, n});
+            job_u = 'A';
+            job_vt = 'O';
+        } else {
+            u = x;
+            vt = zeros<T>(n, n);
+            job_u = 'O';
+            job_vt = 'S';
+        }
+        u_ptr = u.raw_ptr();
+        vt_ptr = vt.raw_ptr();
+
+    } else {
+        u_ptr = nullptr;
+        vt_ptr = nullptr;
+        job_u = 'N';
+        job_vt = 'N';
+    }
+
+    // Perform SVD
+    auto dev_info = zeros<int>(1);
+    auto s = zeros<T>(n);
+    auto rwork = zeros<T>(n - 1);
+    auto gesvd = cuda::CuSolverFunc<T>::gesvd();
+    cuda::check_cusolver_status(gesvd(handle, job_u, job_vt, m, n, x.raw_ptr(), m, s.raw_ptr(), u_ptr, m, vt_ptr, n, buffer.raw_ptr(), buffer_size,
+                                      rwork.raw_ptr(), dev_info.raw_ptr()),
+                                "Failed to perform SVD");
+
+    if (trans_flag) {
+        return std::make_tuple(transpose(u), s, transpose(vt));
+    } else {
+        return std::make_tuple(vt, s, u);
+    }
+}
+
+/**
+ * @brief Batched Singular Value Decomposition.
+ *
+ * @tparam T: Data type of the tensor.
+ * @tparam N: Number of dimensions of the tensor.
+ * @param tensor: The tensor object to be decomposed.
+ * @param full_matrices: If True, it returns u and v with full dimensions.
+ * @param compute_uv: If False, it only returns singular values.
+ * @param handle: The CuSolver handle. The default is the global CuSolver handle.
+ * @return A tuple of U, S, V, where tensor = U * diag(S) * V. (diag neeeded to be implemented)
+ */
+template <typename T, size_t N>
+std::tuple<Tensor<T, N>, Tensor<T, N - 1>, Tensor<T, N>> svd(Tensor<T, N>& tensor, bool full_matrices = true, bool compute_uv = true,
+                                                             cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+    auto shape = tensor.shape();
+    size_t batch_size = std::accumulate(shape.begin(), shape.begin() + (N - 2), 1, std::multiplies<size_t>());
+
+    auto m = shape[N - 2];
+    auto n = shape[N - 1];
+    auto a = copy(moveaxis(tensor, N - 2, N - 1));
+
+    auto lda = m;
+    auto mn = std::min(m, n);
+    auto s = zeros<T>(batch_size, mn);
+    auto ldu = m;
+    auto ldv = n;
+
+    // Get buffer size and info.
+    cusolverEigMode_t jobz = compute_uv ? CUSOLVER_EIG_MODE_VECTOR : CUSOLVER_EIG_MODE_NOVECTOR;
+    auto u = moveaxis(zeros<T>(Shape<3>{batch_size, m, ldu}), N - 2, N - 1);
+    auto v = moveaxis(zeros<T>(Shape<3>{batch_size, n, ldv}), N - 2, N - 1);
+    auto helper = cuda::CuSolverFunc<T>::gesvdj_batched_buffer_size();
+    gesvdjInfo_t params;
+    int lwork;
+    cuda::check_cusolver_status(cusolverDnCreateGesvdjInfo(&params), "Failed to create gesvdj info");
+    cuda::check_cusolver_status(helper(handle, jobz, m, n, a.raw_ptr(), lda, s.raw_ptr(), u.raw_ptr(), ldu, v.raw_ptr(), ldv, &lwork, params, batch_size),
+                                "Failed to get buffer size");
+
+    // Perform SVD
+    auto work = zeros<T>(lwork);
+    auto info = zeros<int>(batch_size);
+
+    auto gesvdj = cuda::CuSolverFunc<T>::gesvdj_batched();
+    cuda::check_cusolver_status(gesvdj(handle, jobz, m, n, a.raw_ptr(), lda, s.raw_ptr(), u.raw_ptr(), ldu, v.raw_ptr(), ldv, work.raw_ptr(), lwork,
+                                       info.raw_ptr(), params, batch_size),
+                                "Failed to perform gesvdj");
+
+    cuda::check_cusolver_status(cusolverDnDestroyGesvdjInfo(params), "Failed to destroy gesvdj info");
+
+    // Need a better way to handle slicing
+    if (!full_matrices) {
+        std::array<Slice, N> slices;
+        std::transform(shape.begin(), shape.begin() + (N - 2), slices.begin(), [](auto dim) { return Slice{0, dim}; });
+        slices[N - 2] = Slice{0, m};
+        slices[N - 1] = Slice{0, mn};
+        u = u(slices);
+        slices[N - 2] = Slice{0, n};
+        v = v(slices);
+    }
+
+    v = moveaxis(v, N - 2, N - 1);
+    return std::make_tuple(u, s, v);
+}
+
+}  // namespace linalg
+
+}  // namespace vt

--- a/lib/linalg/tests/BUILD
+++ b/lib/linalg/tests/BUILD
@@ -9,6 +9,7 @@ cuda_test(
         "test_inv.cc",
         "test_matmul.cc",
         "test_product.cc",
+        "test_svd.cc",
     ],
     copts = ["-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"],
     deps = [

--- a/lib/linalg/tests/test_inv.cc
+++ b/lib/linalg/tests/test_inv.cc
@@ -3,7 +3,7 @@
 #include <vector>
 #include <lib/vtensor.hpp>
 
-TEST(Inv2D, BasicAssertions) {
+TEST(Inv, BasicAssertions) {
     auto tensor = vt::arange(4).reshape(2, 2);
 
     auto handle = vt::cuda::cusolver.get_handle();
@@ -12,7 +12,7 @@ TEST(Inv2D, BasicAssertions) {
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{-1.5, 0.5, 1, 0}));
 }
 
-TEST(Inv3D, BasicAssertions) {
+TEST(BatchedInv, BasicAssertions) {
     auto vec = std::vector<float>{0, 1, 2, 3, 0, 1, 2, 3};
     auto tensor = vt::astensor(vec).reshape(2, 2, 2);
     auto re = vt::linalg::inv(tensor);

--- a/lib/linalg/tests/test_svd.cc
+++ b/lib/linalg/tests/test_svd.cc
@@ -1,0 +1,211 @@
+#include <gtest/gtest.h>
+
+#include <lib/vtensor.hpp>
+
+TEST(SVDFullMatrix1, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(4, 3);
+    auto [vt, s, u] = vt::linalg::svd(tensor);
+
+    auto s1 = vt::asvector(s);
+    std::vector<float> s2 = {2.2446751e+01, 1.4640590e+00, 5.8867556e-07};
+    for (int i = 0; i < s1.size(); i++) {
+        EXPECT_NEAR(s1[i], s2[i], 1e-6);
+    }
+
+    auto vt1 = vt::asvector(vt);
+    std::vector<float> vt2 = {
+        -0.08351804,  0.83248144,  0.5426417,  -0.0744282,
+        -0.31365088,  0.44902438, -0.6680477,   0.503699,
+        -0.54378384,  0.06556801, -0.2918319,  -0.7841137,
+        -0.7739167,  -0.31788802,  0.41723716,  0.35484284
+    };
+    for (int i = 0; i < vt1.size(); i++) {
+        EXPECT_NEAR(vt1[i], vt2[i], 1e-6);
+    }
+
+    auto u1 = vt::asvector(u);
+    std::vector<float> u2 = {
+        -0.49757335, -0.5739708,  -0.65036786,
+        -0.7653458,  -0.06237787,  0.6405894,
+        -0.40824816,  0.81649655, -0.4082485
+    };
+    for (int i = 0; i < u1.size(); i++) {
+        EXPECT_NEAR(u1[i], u2[i], 1e-6);
+    }
+}
+
+TEST(SVDFullMatrix2, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(3, 4);
+    auto [vt, s, u] = vt::linalg::svd(tensor);
+
+    auto s1 = vt::asvector(s);
+    std::vector<float> s2 = {2.2409296e+01, 1.9553399e+00, 3.9066444e-07};
+    for (int i = 0; i < s1.size(); i++) {
+        EXPECT_NEAR(s1[i], s2[i], 1e-6);
+    }
+
+    auto vt1 = vt::asvector(vt);
+    std::vector<float> vt2 = {
+        -0.1473065,  -0.9009075,   0.40824804,
+        -0.50027525, -0.28819758, -0.8164966,
+        -0.853244,    0.32451168,  0.40824842
+    };
+    for (int i = 0; i < vt1.size(); i++) {
+        EXPECT_NEAR(vt1[i], vt2[i], 1e-6);
+    }
+
+    auto u1 = vt::asvector(u);
+    std::vector<float> u2 = {
+        -0.39390135, -0.4608747,  -0.52784806, -0.59482133,
+         0.7381339,   0.2959636,  -0.14620665, -0.58837706,
+         0.42559415, -0.82443875,  0.37209475,  0.02674968,
+         0.34477443, -0.1424799,  -0.74936336,  0.54706883
+    };
+    for (int i = 0; i < u1.size(); i++) {
+        EXPECT_NEAR(u1[i], u2[i], 1e-6);
+    }
+}
+
+TEST(SVDNotFullMatrix1, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(4, 3);
+    auto [vt, s, u] = vt::linalg::svd(tensor, false);
+
+    auto s1 = vt::asvector(s);
+    std::vector<float> s2 = {2.2446751e+01, 1.4640590e+00, 5.8867556e-07};
+    for (int i = 0; i < s1.size(); i++) {
+        EXPECT_NEAR(s1[i], s2[i], 1e-6);
+    }
+
+    auto vt1 = vt::asvector(vt);
+    std::vector<float> vt2 = {
+        -0.08351804,  0.83248144,  0.5426417,
+        -0.31365088,  0.44902438, -0.6680477,
+        -0.54378384,  0.06556801, -0.2918319,
+        -0.7739167,  -0.31788802,  0.41723716,
+    };
+
+    for (int i = 0; i < vt1.size(); i++) {
+        EXPECT_NEAR(vt1[i], vt2[i], 1e-6);
+    }
+
+    auto u1 = vt::asvector(u);
+    std::vector<float> u2 = {
+        -0.49757335, -0.5739708,  -0.65036786,
+        -0.7653458,  -0.06237787,  0.6405894,
+        -0.40824816,  0.81649655, -0.4082485
+    };
+    for (int i = 0; i < u1.size(); i++) {
+        EXPECT_NEAR(u1[i], u2[i], 1e-6);
+    }
+}
+
+TEST(SVDNotFullMatrix2, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(3, 4);
+    auto [vt, s, u] = vt::linalg::svd(tensor, false);
+
+    auto s1 = vt::asvector(s);
+    std::vector<float> s2 = {2.2409296e+01, 1.9553399e+00, 3.9066444e-07};
+    for (int i = 0; i < s1.size(); i++) {
+        EXPECT_NEAR(s1[i], s2[i], 1e-6);
+    }
+
+    auto vt1 = vt::asvector(vt);
+    std::vector<float> vt2 = {
+        -0.1473065,  -0.9009075,   0.40824804,
+        -0.50027525, -0.28819758, -0.8164966,
+        -0.853244,    0.32451168,  0.40824842
+    };
+    for (int i = 0; i < vt1.size(); i++) {
+        EXPECT_NEAR(vt1[i], vt2[i], 1e-6);
+    }
+
+    auto u1 = vt::asvector(u);
+    std::vector<float> u2 = {
+        -0.39390135, -0.4608747,  -0.52784806, -0.59482133,
+         0.7381339,   0.2959636,  -0.14620665, -0.58837706,
+         0.42559415, -0.82443875,  0.37209475,  0.02674968,
+    };
+    for (int i = 0; i < u1.size(); i++) {
+        EXPECT_NEAR(u1[i], u2[i], 1e-6);
+    }
+}
+
+TEST(SVDNotComputUV1, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(4, 3);
+    auto [vt, s, u] = vt::linalg::svd(tensor, false, false);
+    auto s1 = vt::asvector(s);
+    std::vector<float> s2 = {2.2446751e+01, 1.4640590e+00, 5.8867556e-07};
+    for (int i = 0; i < s1.size(); i++) {
+        EXPECT_NEAR(s1[i], s2[i], 1e-6);
+    }
+}
+
+TEST(SVDNotComputUV2, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(3, 4);
+    auto [vt, s, u] = vt::linalg::svd(tensor, false, false);
+    auto s1 = vt::asvector(s);
+    std::vector<float> s2 = {2.2409296e+01, 1.9553399e+00, 3.9066444e-07};
+    for (int i = 0; i < s1.size(); i++) {
+        EXPECT_NEAR(s1[i], s2[i], 1e-6);
+    }
+}
+
+TEST(BatchedSVDFullMatrix, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(2, 3, 2);
+    auto [vt, s, u] = vt::linalg::svd(tensor);
+    auto s1 = vt::asvector(s);
+    std::vector<float> s2 = {7.386483, 0.66323584, 21.235508, 0.23069805};
+    for (int i = 0; i < s1.size(); i++) {
+        EXPECT_NEAR(s1[i], s2[i], 1e-6);
+    }
+
+    auto vt1 = vt::asvector(vt);
+    std::vector<float> vt2 = {
+        -0.10818539, -0.9064377,  0.40824834,
+        -0.48733622, -0.30957523, -0.81649655,
+        -0.86648697,  0.28728768,  0.40824825,
+        -0.43406904, -0.8030684,  0.40824732,
+        -0.5670487,  -0.10857622, -0.8164968,
+        -0.7000285,   0.58591187,  0.4082491
+    };
+    for (int i = 0; i < vt1.size(); i++) {
+        EXPECT_NEAR(vt1[i], vt2[i], 1e-6);
+    }
+
+    auto u1 = vt::asvector(u);
+    std::vector<float> u2 = {
+        -0.6011819,  -0.79911214,  0.79911214, -0.6011819,
+        -0.66591716, -0.74602574,  0.74602574, -0.66591716
+    };
+    for (int i = 0; i < u1.size(); i++) {
+        EXPECT_NEAR(u1[i], u2[i], 1e-6);
+    }
+}
+
+TEST(BatchedSVDNotFullMatrix, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(2, 3, 2);
+    auto [vt, s, u] = vt::linalg::svd(tensor, false);
+    auto s1 = vt::asvector(s);
+    std::vector<float> s2 = {7.386483, 0.66323584, 21.235508, 0.23069805};
+    for (int i = 0; i < s1.size(); i++) {
+        EXPECT_NEAR(s1[i], s2[i], 1e-6);
+    }
+
+    auto vt1 = vt::asvector(vt);
+    std::vector<float> vt2 = {
+        -0.10818539, -0.9064377,  -0.48733622, -0.30957523, -0.86648697,  0.28728768,
+        -0.43406904, -0.8030684,  -0.5670487,  -0.10857622, -0.7000285,   0.58591187
+    };
+    for (int i = 0; i < vt1.size(); i++) {
+        EXPECT_NEAR(vt1[i], vt2[i], 1e-6);
+    }
+
+    auto u1 = vt::asvector(u);
+    std::vector<float> u2 = {
+        -0.6011819,  -0.79911214,  0.79911214, -0.6011819,
+        -0.66591716, -0.74602574,  0.74602574, -0.66591716
+    };
+    for (int i = 0; i < u1.size(); i++) {
+        EXPECT_NEAR(u1[i], u2[i], 1e-6);
+    }
+}

--- a/lib/logical/all.hpp
+++ b/lib/logical/all.hpp
@@ -22,7 +22,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 bool all(const Tensor<T, N>& tensor) {
-    if (!tensor.sliced())
+    if (tensor.contiguous())
         return thrust::all_of(tensor.begin(), tensor.end(), thrust::identity<bool>());
     else
         return thrust::count_if(tensor.begin(), tensor.end(), thrust::identity<bool>()) == tensor.size();

--- a/lib/logical/any.hpp
+++ b/lib/logical/any.hpp
@@ -21,7 +21,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 bool any(const Tensor<T, N>& tensor) {
-    if (!tensor.sliced())
+    if (tensor.contiguous())
         return thrust::any_of(tensor.begin(), tensor.end(), thrust::identity<bool>());
     else
         return thrust::count_if(tensor.begin(), tensor.end(), thrust::identity<bool>());

--- a/lib/math/tests/test_transpose.cc
+++ b/lib/math/tests/test_transpose.cc
@@ -5,21 +5,20 @@
 TEST(Transpose, BasicAssertions) {
     auto tensor = vt::arange(12).reshape(3, 2, 2);
     auto tensor1 = vt::transpose(tensor);
-
     EXPECT_EQ(tensor.size(), 12);
     EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{3, 2, 2}));
     EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{4, 2, 1}));
     EXPECT_EQ(tensor.start(), 0);
-    EXPECT_EQ(tensor.sliced(), false);
+    EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 
     EXPECT_EQ(tensor1.size(), 12);
     EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{2, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{1, 2, 4}));
     EXPECT_EQ(tensor1.start(), 0);
-    EXPECT_EQ(tensor1.sliced(), false);
+    EXPECT_EQ(tensor1.contiguous(), false);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
-    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 4, 8, 2, 6, 10, 1, 5, 9, 3, 7, 11}));
 }
 
 TEST(TransposeWithAxis, BasicAssertions) {
@@ -30,16 +29,16 @@ TEST(TransposeWithAxis, BasicAssertions) {
     EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{3, 2, 2}));
     EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{4, 2, 1}));
     EXPECT_EQ(tensor.start(), 0);
-    EXPECT_EQ(tensor.sliced(), false);
+    EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 
     EXPECT_EQ(tensor1.size(), 12);
     EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{2, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{1, 2, 4}));
     EXPECT_EQ(tensor1.start(), 0);
-    EXPECT_EQ(tensor1.sliced(), false);
+    EXPECT_EQ(tensor1.contiguous(), false);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
-    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 4, 8, 2, 6, 10, 1, 5, 9, 3, 7, 11}));
 }
 
 TEST(MoveAxis, BasicAssertions) {
@@ -51,14 +50,14 @@ TEST(MoveAxis, BasicAssertions) {
     EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{3, 2, 2}));
     EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{4, 2, 1}));
     EXPECT_EQ(tensor.start(), 0);
-    EXPECT_EQ(tensor.sliced(), false);
+    EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 
     EXPECT_EQ(tensor1.size(), 12);
     EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{2, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{1, 2, 4}));
     EXPECT_EQ(tensor1.start(), 0);
-    EXPECT_EQ(tensor1.sliced(), false);
+    EXPECT_EQ(tensor1.contiguous(), false);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
-    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 4, 8, 2, 6, 10, 1, 5, 9, 3, 7, 11}));
 }

--- a/lib/math/transpose.hpp
+++ b/lib/math/transpose.hpp
@@ -6,6 +6,7 @@ namespace vt {
 
 /**
  * @brief Transpose the tensor.
+ * After transpose, it is not quaranteed that the tensor is contiguous.
  *
  * @tparam T: Data type of the tensor.
  * @tparam N: Number of dimensions of the tensor.
@@ -22,11 +23,12 @@ Tensor<T, N> transpose(const Tensor<T, N>& tensor) {
         new_shape[i] = shape[N - i - 1];
         new_strides[i] = strides[N - i - 1];
     }
-    return Tensor(tensor.data(), new_shape, new_strides, tensor.start(), tensor.sliced());
+    return Tensor(tensor.data(), new_shape, new_strides, tensor.start(), false);
 }
 
 /**
  * @brief Transpose the tensor with given axes.
+ * After transpose, it is not quaranteed that the tensor is contiguous.
  *
  * @tparam T: Data type of the tensor.
  * @tparam N: Number of dimensions of the tensor.
@@ -44,7 +46,7 @@ Tensor<T, N> transpose(const Tensor<T, N>& tensor, const Shape<N>& axes) {
         new_shape[i] = shape[axes[i]];
         new_strides[i] = strides[axes[i]];
     }
-    return Tensor(tensor.data(), new_shape, new_strides, tensor.start(), tensor.sliced());
+    return Tensor(tensor.data(), new_shape, new_strides, tensor.start(), false);
 }
 
 /**

--- a/lib/memory/ascontiguoustensor.hpp
+++ b/lib/memory/ascontiguoustensor.hpp
@@ -7,7 +7,7 @@ namespace vt {
 
 /**
  * @brief Convert the tensor to a contiguous tensor.
- * If the tensor has been sliced, it will copy and return a new tensor. Otherwise, it will return the same tensor.
+ * If the tensor is not contiguous, it will copy and return a new tensor. Otherwise, it will return the same tensor.
  *
  * @tparam T: Data type of the tensor.
  * @tparam N: Number of dimensions of the tensor.
@@ -16,7 +16,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, N> ascontiguoustensor(const Tensor<T, N>& tensor) {
-    if (tensor.sliced()) {
+    if (!tensor.contiguous()) {
         return copy(tensor);
     } else {
         return tensor;

--- a/lib/memory/astensor.hpp
+++ b/lib/memory/astensor.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <vector>
 #include <lib/core/tensor.hpp>
 #include <lib/generator/zeros.hpp>
+#include <vector>
 
 namespace vt {
 

--- a/lib/memory/fileio.hpp
+++ b/lib/memory/fileio.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <vector>
 #include <lib/core/tensor.hpp>
 #include <lib/memory/astensor.hpp>
 #include <lib/memory/asvector.hpp>
+#include <vector>
 
 #include "cnpy.h"
 

--- a/lib/vtensor.hpp
+++ b/lib/vtensor.hpp
@@ -12,6 +12,7 @@
 #include <lib/linalg/inv.hpp>
 #include <lib/linalg/matmul.hpp>
 #include <lib/linalg/product.hpp>
+#include <lib/linalg/svd.hpp>
 #include <lib/logical/all.hpp>
 #include <lib/logical/any.hpp>
 #include <lib/math/max.hpp>


### PR DESCRIPTION
1. Support SVD and batched SVD
2. Fix the transpose bug by setting `contiguous=false`
3. Replace sliced flag with contiguous for the memory layout.