### PR TITLE
[VTEN-6] Add Ellipsis slice

### DIFF
--- a/docs/source/api/core/slice.rst
+++ b/docs/source/api/core/slice.rst
@@ -4,6 +4,9 @@ Slice
 .. toctree::
    :maxdepth: 1
 
+.. doxygenstruct:: vt::EllipsisT
+   :members:
+
 .. doxygenclass:: vt::Slice
    :members:
 

--- a/docs/source/api/core/tensor.rst
+++ b/docs/source/api/core/tensor.rst
@@ -6,8 +6,9 @@ Tensor
 
 .. doxygentypedef:: vt::Shape
 
-.. doxygenfunction:: vt::get_size(const Shape<N>& shape)
-.. doxygenfunction:: vt::get_strides(const Shape<N>& shape)
+.. doxygenfunction:: vt::get_size
+.. doxygenfunction:: vt::get_strides
+.. doxygenfunction:: vt::expand_shape
 
 .. doxygenclass:: vt::Tensor
    :members:

--- a/lib/core/slice.hpp
+++ b/lib/core/slice.hpp
@@ -45,6 +45,17 @@ class Slice {
     Slice(size_t start, size_t end, size_t step) : start(start), end(end), step(step) {}
 };
 
+/**
+ * @brief Represents an ellipsis in tensor operations.
+ *
+ * The EllipsisT struct is used to signify an ellipsis in tensor slicing operations.
+ * A global static object of this type, named `ellipsis`, is defined for convenience.
+ */
+struct EllipsisT {};
+
+/// Ellipsis object
+static constexpr EllipsisT ellipsis = {};
+
 /// Forward declaration of the Tensor class.
 template <typename T, size_t N>
 class Tensor;

--- a/lib/core/tests/test_tensor.cc
+++ b/lib/core/tests/test_tensor.cc
@@ -6,10 +6,14 @@ TEST(HelperFunctions, BasicAssertions) {
     auto shape = std::array<size_t, 3>{1, 2, 3};
     auto stides = vt::get_strides(shape);
     auto size = vt::get_size(shape);
+    auto expanded_shape = vt::expand_shape(shape, 4, 5, 6);
     EXPECT_EQ(size, 6);
     EXPECT_EQ(stides[0], 6);
     EXPECT_EQ(stides[1], 3);
     EXPECT_EQ(stides[2], 1);
+    for (size_t i = 0; i < 6; i++) {
+        EXPECT_EQ(expanded_shape[i], i + 1);
+    }
 }
 
 TEST(TensorConstructor, BasicAssertions) {
@@ -119,6 +123,12 @@ TEST(TensorSliceOperation, BasicAssertions) {
     auto tensor4 = vt::zeros(vt::Shape<3>{2, 2, 2});
     std::array<vt::Slice, 3> slices = {vt::Slice(0, 2, 1), vt::Slice(0, 2, 1), vt::Slice(0, 2, 1)};
     tensor4(slices);
+}
+
+TEST(TensorEllipsisSlices, BasicAssertions){
+    auto tensor = vt::arange(12).reshape(2, 2, 3);
+    tensor = tensor(vt::ellipsis, {0, 2});
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 3, 4, 6, 7, 9, 10}));
 }
 
 TEST(TensorSliceAlongTheAxisOperation, BasicAssertions) {


### PR DESCRIPTION
1. Add a placeholder for ellipsis, so we could slice the tensor with `tensor[vt::ellipsis, {0, 5}]` which is similar as python array[..., 0:5]
2. Add `expand_shape` helper function.
3. Fix the bug for batch SVD with higher dimension.