### PR TITLE
[VTEN-16] Add F-order memory layout 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,6 @@ sphinx-build -b html docs/source docs/build/html
 ```
 
 ### Future updates
-- Support GPUDirect
+- The current tensor supports both "C" and "F" memory layouts. However, mixed order operations are not prohibited, and the "F" order does not fully support linear algebra functions.
 - Support more matrix operations
 - Support Sparse martix with CuSparse

--- a/docs/source/api/core/iterator.rst
+++ b/docs/source/api/core/iterator.rst
@@ -4,5 +4,8 @@ vt::TensorIterator
 .. toctree::
    :maxdepth: 1
 
+.. doxygenenum:: vt::Order
+   :members:
+
 .. doxygenclass:: vt::TensorIterator
    :members:

--- a/docs/source/api/core/mempool.rst
+++ b/docs/source/api/core/mempool.rst
@@ -13,4 +13,5 @@ vt::Mempool
 .. doxygenclass:: vt::GlobalMempool
    :members:
 
-.. doxygenvariable:: vt::instance
+.. doxygenclass:: vt::GlobalMempoolInitializer
+   :members:

--- a/docs/source/api/generator/arange.rst
+++ b/docs/source/api/generator/arange.rst
@@ -4,6 +4,6 @@ vt::arange
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::arange(int step)
-.. doxygenfunction:: vt::arange(T start, T end, T step)
-.. doxygenfunction:: vt::arange(T* start, T* end, int step)
+.. doxygenfunction:: vt::arange(int step, const Order order = Order::C)
+.. doxygenfunction:: vt::arange(T start, T end, T step, const Order order = Order::C)
+.. doxygenfunction:: vt::arange(T* start, T* end, int step, const Order order = Order::C)

--- a/docs/source/api/generator/eye.rst
+++ b/docs/source/api/generator/eye.rst
@@ -4,5 +4,5 @@ vt::eye
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::eye(size_t m)
-.. doxygenfunction:: vt::eye(size_t m, size_t n)
+.. doxygenfunction:: vt::eye(size_t m, const Order order = Order::C)
+.. doxygenfunction:: vt::eye(size_t m, size_t n, const Order order = Order::C)

--- a/docs/source/api/generator/ones.rst
+++ b/docs/source/api/generator/ones.rst
@@ -4,6 +4,6 @@ vt::ones
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::ones(Shape<N> shape)
-.. doxygenfunction:: vt::ones(size_t m)
-.. doxygenfunction:: vt::ones(size_t m, size_t n)
+.. doxygenfunction:: vt::ones(Shape<N> shape, const Order order = Order::C)
+.. doxygenfunction:: vt::ones(size_t m, const Order order = Order::C)
+.. doxygenfunction:: vt::ones(size_t m, size_t n, const Order order = Order::C)

--- a/docs/source/api/generator/zeros.rst
+++ b/docs/source/api/generator/zeros.rst
@@ -4,6 +4,6 @@ vt::zeros
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::zeros(Shape<N> shape)
-.. doxygenfunction:: vt::zeros(size_t m)
-.. doxygenfunction:: vt::zeros(size_t m, size_t n)
+.. doxygenfunction:: vt::zeros(Shape<N> shape, const Order order = Order::C)
+.. doxygenfunction:: vt::zeros(size_t m, const Order order = Order::C)
+.. doxygenfunction:: vt::zeros(size_t m, size_t n, const Order order = Order::C)

--- a/docs/source/api/memory/ascontiguoustensor.rst
+++ b/docs/source/api/memory/ascontiguoustensor.rst
@@ -4,4 +4,4 @@ vt::ascontiguoustensor
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::ascontiguoustensor(const Tensor<T, N>& tensor)
+.. doxygenfunction:: vt::ascontiguoustensor

--- a/docs/source/api/memory/asfortrantensor.rst
+++ b/docs/source/api/memory/asfortrantensor.rst
@@ -4,4 +4,4 @@ vt::asfortrantensor
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::asfortrantensor(Tensor<T, 2>& tensor)
+.. doxygenfunction:: vt::asfortrantensor

--- a/docs/source/api/memory/astensor.rst
+++ b/docs/source/api/memory/astensor.rst
@@ -4,7 +4,7 @@ vt::astensor
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::astensor(const std::vector<T>& vector)
-.. doxygenfunction:: vt::astensor(const xt::xarray<T>& arr)
-.. doxygenfunction:: vt::astensor(const T* ptr, const size_t size)
-.. doxygenfunction:: vt::astensor(const T* ptr, const Shape<N> shape)
+.. doxygenfunction:: vt::astensor(const std::vector<T>& vector, const Order order = Order::C)
+.. doxygenfunction:: vt::astensor(const xt::xarray<T, L>& arr)
+.. doxygenfunction:: vt::astensor(const T* ptr, const size_t size, const Order order = Order::C)
+.. doxygenfunction:: vt::astensor(const T* ptr, const Shape<N> shape, const Order order = Order::C)

--- a/docs/source/api/memory/asvector.rst
+++ b/docs/source/api/memory/asvector.rst
@@ -4,4 +4,4 @@ vt::asvector
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::asvector(const Tensor<T, N>& tensor)
+.. doxygenfunction:: vt::asvector

--- a/docs/source/api/memory/copy.rst
+++ b/docs/source/api/memory/copy.rst
@@ -4,4 +4,4 @@ vt::copy
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::copy(const Tensor<T, N>& tensor)
+.. doxygenfunction:: vt::copy

--- a/docs/source/api/memory/load.rst
+++ b/docs/source/api/memory/load.rst
@@ -4,4 +4,4 @@ vt::load
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::load(const std::string& filename)
+.. doxygenfunction:: vt::load

--- a/docs/source/api/memory/save.rst
+++ b/docs/source/api/memory/save.rst
@@ -4,4 +4,4 @@ vt::save
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::save(const std::string& filename, const Tensor<T, N>& tensor)
+.. doxygenfunction:: vt::save

--- a/docs/source/api/random/normal.rst
+++ b/docs/source/api/random/normal.rst
@@ -4,6 +4,6 @@ vt::normal
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::random::normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, curandGenerator_t gen = cuda::curand.get_handle())
-.. doxygenfunction:: vt::random::normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, curandGenerator_t gen = cuda::curand.get_handle())
-.. doxygenfunction:: vt::random::normal(size_t m, size_t n, T mean = T{0.0}, T stddev = T{1.0}, curandGenerator_t gen = cuda::curand.get_handle())
+.. doxygenfunction:: vt::random::normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
+.. doxygenfunction:: vt::random::normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
+.. doxygenfunction:: vt::random::normal(size_t m, size_t n, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())

--- a/docs/source/api/random/rand.rst
+++ b/docs/source/api/random/rand.rst
@@ -4,6 +4,6 @@ vt::rand
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::random::rand(Shape<N> shape, curandGenerator_t gen = cuda::curand.get_handle())
-.. doxygenfunction:: vt::random::rand(size_t m, curandGenerator_t gen = cuda::curand.get_handle())
-.. doxygenfunction:: vt::random::rand(size_t m, size_t n, curandGenerator_t gen = cuda::curand.get_handle())
+.. doxygenfunction:: vt::random::rand(Shape<N> shape, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
+.. doxygenfunction:: vt::random::rand(size_t m, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
+.. doxygenfunction:: vt::random::rand(size_t m, size_t n, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())

--- a/lib/core/assertions.hpp
+++ b/lib/core/assertions.hpp
@@ -1,7 +1,11 @@
 
 #pragma once
 
+#include <cassert>
+
 namespace vt {
+
+enum class Order : char;
 
 /**
  * @brief Assert that the tensor is at least 1D.
@@ -32,5 +36,13 @@ template <size_t N>
 constexpr void assert_at_least_3d_tensor() {
     static_assert(N > 2, "The tensor must be at least 3D.");
 }
+
+/**
+ * @brief Assert same memory layout order for two tensors.
+ *
+ * @param order1: The order of the first tensor.
+ * @param order2: The order of the second tensor.
+ */
+inline void assert_same_order_between_two_tensors(const Order order1, const Order order2) { assert(order1 == order2); }
 
 }  // namespace vt

--- a/lib/core/astype.hpp
+++ b/lib/core/astype.hpp
@@ -22,7 +22,7 @@ Tensor<U, N> astype(Tensor<T, N> tensor) {
     if constexpr (std::is_same_v<T, U>) {
         return tensor;
     } else {
-        auto result = Tensor<U, N>(tensor.shape());
+        auto result = Tensor<U, N>(tensor.shape(), tensor.order());
         thrust::transform(tensor.begin(), tensor.end(), result.begin(), [] __device__(const T& x) { return static_cast<U>(x); });
         return result;
     }

--- a/lib/core/broadcast.hpp
+++ b/lib/core/broadcast.hpp
@@ -64,7 +64,7 @@ Tensor<T, N> broadcast_to(const Tensor<T, N>& tensor, const Shape<N>& broadcast_
             broadcast_strides[i] = strides[i];
         }
     }
-    return Tensor<T, N>(tensor.data(), broadcast_shape, broadcast_strides, tensor.start(), false);
+    return Tensor<T, N>(tensor.data(), broadcast_shape, broadcast_strides, tensor.start(), tensor.order(), false);
 }
 
 }  // namespace vt

--- a/lib/core/cutensor.hpp
+++ b/lib/core/cutensor.hpp
@@ -22,7 +22,7 @@ class CuTensor {
      * @param tensor: The tensor to be adapted.
      */
     __host__ CuTensor(Tensor<T, N> tensor)
-        : CuTensor(tensor.raw_ptr(), tensor.shape().data(), tensor.strides().data(), tensor.start(), tensor.size(), tensor.contiguous()) {}
+        : CuTensor(tensor.raw_ptr(), tensor.shape().data(), tensor.strides().data(), tensor.start(), tensor.size(), tensor.order(), tensor.contiguous()) {}
 
     /**
      * @brief Construct a new CuTensor object from a raw pointer, shape, strides, start index, and contiguous flag.
@@ -31,10 +31,13 @@ class CuTensor {
      * @param shape: The shape of the tensor.
      * @param strides: The strides of the tensor.
      * @param start: The start index of the tensor.
+     * @param size: The size of the tensor.
+     * @param order: The order of the tensor.
      * @param contiguous: The contiguous flag of the tensor.
      */
-    __host__ __device__ CuTensor(T* data, const size_t* shape, const size_t* strides, const size_t start, const size_t size, const bool contiguous)
-        : data(data), start(start), size(size), contiguous(contiguous) {
+    __host__ __device__ CuTensor(T* data, const size_t* shape, const size_t* strides, const size_t start, const size_t size, const Order order,
+                                 const bool contiguous)
+        : data(data), start(start), size(size), order(order), contiguous(contiguous) {
         if constexpr (N > 0) {
             for (size_t i = 0; i < N; ++i) {
                 this->shape[i] = shape[i];
@@ -91,7 +94,7 @@ class CuTensor {
      * @param n: The 1D index of the tensor.
      * @return T: The data of the tensor.
      */
-    __host__ __device__ T& operator[](size_t n) { return contiguous ? data[n] : data[get_iterator_index<N>(n, shape, strides, start)]; }
+    __host__ __device__ T& operator[](size_t n) { return contiguous ? data[n] : data[get_iterator_index<N>(n, shape, strides, start, order)]; }
 
     /**
      * @brief Return the data given the iterative index
@@ -99,13 +102,14 @@ class CuTensor {
      * @param n: The 1D index of the tensor.
      * @return T: The data of the tensor.
      */
-    __host__ __device__ const T& operator[](size_t n) const { return contiguous ? data[n] : data[get_iterator_index<N>(n, shape, strides, start)]; }
+    __host__ __device__ const T& operator[](size_t n) const { return contiguous ? data[n] : data[get_iterator_index<N>(n, shape, strides, start, order)]; }
 
     size_t shape[N];
     size_t strides[N];
     size_t start;
     size_t size = 0;
     bool contiguous;
+    Order order;
     T* data;
 };
 

--- a/lib/core/iterator.hpp
+++ b/lib/core/iterator.hpp
@@ -5,6 +5,11 @@
 namespace vt {
 
 /**
+ * @brief Order of the tensor.
+ */
+enum class Order : char { C, F };
+
+/**
  * @brief Get the iterator index.
  *
  * @tparam N: Number of dimensions.
@@ -12,17 +17,26 @@ namespace vt {
  * @param shape: The shape of the tensor.
  * @param strides: The strides of the tensor.
  * @param start: The start index of the tensor.
- * @return size_t: The index of the iterator.
+ * @param order: The order of the tensor.
  */
 template <size_t N>
-__host__ __device__ size_t get_iterator_index(size_t n, const size_t* shape, const size_t* strides, size_t start) {
+__host__ __device__ size_t get_iterator_index(size_t n, const size_t* shape, const size_t* strides, size_t start, Order order) {
     size_t index = start;
     if constexpr (N > 0) {
-        for (size_t i = 0; i < N; ++i) {
-            size_t shape_product = 1;
-            for (size_t j = i + 1; j < N; ++j) shape_product *= shape[j];
-            index += (n / shape_product) * strides[i];
-            n %= shape_product;
+        if (order == Order::C) {
+            for (size_t i = 0; i < N; ++i) {
+                size_t shape_product = 1;
+                for (size_t j = i + 1; j < N; ++j) shape_product *= shape[j];
+                index += (n / shape_product) * strides[i];
+                n %= shape_product;
+            }
+        } else {
+            for (size_t i = N; i-- > 0;) {
+                size_t shape_product = 1;
+                for (size_t j = 0; j < i; ++j) shape_product *= shape[j];
+                index += (n / shape_product) * strides[i];
+                n %= shape_product;
+            }
         }
     }
     return index;
@@ -44,10 +58,12 @@ class TensorIterator : public thrust::iterator_adaptor<TensorIterator<Iterator, 
      * @param shape: The shape of the tensor.
      * @param strides: The strides of the tensor.
      * @param start: The start index of the tensor.
+     * @param order: The order of the tensor.
      * @param contiguous: The contiguous flag of the tensor.
      */
-    __host__ __device__ TensorIterator(const Iterator& iter, const size_t* shape, const size_t* strides, const size_t start, const bool contiguous)
-        : thrust::iterator_adaptor<TensorIterator<Iterator, N>, Iterator>(iter), start(start), contiguous(contiguous) {
+    __host__ __device__ TensorIterator(const Iterator& iter, const size_t* shape, const size_t* strides, const size_t start, const Order order,
+                                       const bool contiguous)
+        : thrust::iterator_adaptor<TensorIterator<Iterator, N>, Iterator>(iter), start(start), order(order), contiguous(contiguous) {
         if constexpr (N > 0) {
             for (size_t i = 0; i < N; ++i) {
                 this->shape[i] = shape[i];
@@ -65,7 +81,7 @@ class TensorIterator : public thrust::iterator_adaptor<TensorIterator<Iterator, 
         if (contiguous) {
             this->base_reference() += n;
         } else {
-            this->base_reference() += get_iterator_index<N>(n, shape, strides, start);
+            this->base_reference() += get_iterator_index<N>(n, shape, strides, start, order);
         }
     }
 
@@ -73,6 +89,7 @@ class TensorIterator : public thrust::iterator_adaptor<TensorIterator<Iterator, 
     size_t shape[N];
     size_t strides[N];
     size_t start;
+    Order order;
     bool contiguous;
 };
 

--- a/lib/core/operator.hpp
+++ b/lib/core/operator.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lib/core/assertions.hpp"
 #include "lib/core/broadcast.hpp"
 #include "lib/core/tensor.hpp"
 
@@ -16,8 +17,9 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator+(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
     auto [_lhs, _rhs] = broadcast(lhs, rhs);
-    auto result = Tensor<T, N>(_lhs.shape());
+    auto result = Tensor<T, N>(_lhs.shape(), _lhs.order());
     thrust::transform(_lhs.begin(), _lhs.end(), _rhs.begin(), result.begin(), thrust::plus<T>());
     return result;
 }
@@ -33,7 +35,7 @@ Tensor<T, N> operator+(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator+(const Tensor<T, N>& lhs, const T value) {
-    auto result = Tensor<T, N>(lhs.shape());
+    auto result = Tensor<T, N>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), thrust::plus<T>());
     return result;
 }
@@ -63,8 +65,9 @@ Tensor<T, N> operator+(const T value, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator-(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
     auto [_lhs, _rhs] = broadcast(lhs, rhs);
-    auto result = Tensor<T, N>(_lhs.shape());
+    auto result = Tensor<T, N>(_lhs.shape(), _lhs.order());
     thrust::transform(_lhs.begin(), _lhs.end(), _rhs.begin(), result.begin(), thrust::minus<T>());
     return result;
 }
@@ -80,7 +83,7 @@ Tensor<T, N> operator-(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator-(const Tensor<T, N>& lhs, const T value) {
-    auto result = Tensor<T, N>(lhs.shape());
+    auto result = Tensor<T, N>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), thrust::minus<T>());
     return result;
 }
@@ -96,7 +99,7 @@ Tensor<T, N> operator-(const Tensor<T, N>& lhs, const T value) {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator-(const T value, const Tensor<T, N>& rhs) {
-    auto result = Tensor<T, N>(rhs.shape());
+    auto result = Tensor<T, N>(rhs.shape(), rhs.order());
     auto iter = thrust::make_constant_iterator(value);
     thrust::transform(iter, iter + rhs.size(), rhs.begin(), result.begin(), thrust::minus<T>());
     return result;
@@ -113,8 +116,9 @@ Tensor<T, N> operator-(const T value, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator*(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
     auto [_lhs, _rhs] = broadcast(lhs, rhs);
-    auto result = Tensor<T, N>(_lhs.shape());
+    auto result = Tensor<T, N>(_lhs.shape(), _lhs.order());
     thrust::transform(_lhs.begin(), _lhs.end(), _rhs.begin(), result.begin(), thrust::multiplies<T>());
     return result;
 }
@@ -130,7 +134,7 @@ Tensor<T, N> operator*(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator*(const Tensor<T, N>& lhs, const T value) {
-    auto result = Tensor<T, N>(lhs.shape());
+    auto result = Tensor<T, N>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), thrust::multiplies<T>());
     return result;
 }
@@ -160,8 +164,9 @@ Tensor<T, N> operator*(const T value, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator/(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
     auto [_lhs, _rhs] = broadcast(lhs, rhs);
-    auto result = Tensor<T, N>(_lhs.shape());
+    auto result = Tensor<T, N>(_lhs.shape(), _lhs.order());
     thrust::transform(_lhs.begin(), _lhs.end(), _rhs.begin(), result.begin(), thrust::divides<T>());
     return result;
 }
@@ -177,7 +182,7 @@ Tensor<T, N> operator/(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator/(const Tensor<T, N>& lhs, const T value) {
-    auto result = Tensor<T, N>(lhs.shape());
+    auto result = Tensor<T, N>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), thrust::divides<T>());
     return result;
 }
@@ -193,7 +198,7 @@ Tensor<T, N> operator/(const Tensor<T, N>& lhs, const T value) {
  */
 template <typename T, size_t N>
 Tensor<T, N> operator/(const T value, const Tensor<T, N>& rhs) {
-    auto result = Tensor<T, N>(rhs.shape());
+    auto result = Tensor<T, N>(rhs.shape(), rhs.order());
     auto iter = thrust::make_constant_iterator(value);
     thrust::transform(iter, iter + rhs.size(), rhs.begin(), result.begin(), thrust::divides<T>());
     return result;
@@ -210,8 +215,9 @@ Tensor<T, N> operator/(const T value, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator>(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
     auto [_lhs, _rhs] = broadcast(lhs, rhs);
-    auto result = Tensor<bool, N>(_lhs.shape());
+    auto result = Tensor<bool, N>(_lhs.shape(), _lhs.order());
     thrust::transform(_lhs.begin(), _lhs.end(), _rhs.begin(), result.begin(), [] __device__(const T& x, const T& y) { return x > y; });
     return result;
 }
@@ -227,7 +233,7 @@ Tensor<bool, N> operator>(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator>(const Tensor<T, N>& lhs, const T value) {
-    auto result = Tensor<bool, N>(lhs.shape());
+    auto result = Tensor<bool, N>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), [] __device__(const T& x, const T& y) { return x > y; });
     return result;
 }
@@ -243,7 +249,7 @@ Tensor<bool, N> operator>(const Tensor<T, N>& lhs, const T value) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator>(const T value, const Tensor<T, N>& rhs) {
-    auto result = Tensor<bool, N>(rhs.shape());
+    auto result = Tensor<bool, N>(rhs.shape(), rhs.order());
     thrust::transform(rhs.begin(), rhs.end(), thrust::make_constant_iterator(value), result.begin(), [] __device__(const T& x, const T& y) { return x < y; });
     return result;
 }
@@ -301,8 +307,9 @@ Tensor<bool, N> operator<(const T value, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator>=(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
     auto [_lhs, _rhs] = broadcast(lhs, rhs);
-    auto result = Tensor<bool, N>(_lhs.shape());
+    auto result = Tensor<bool, N>(_lhs.shape(), _lhs.order());
     thrust::transform(_lhs.begin(), _lhs.end(), _rhs.begin(), result.begin(), [] __device__(const T& x, const T& y) { return x >= y; });
     return result;
 }
@@ -318,7 +325,7 @@ Tensor<bool, N> operator>=(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator>=(const Tensor<T, N>& lhs, const T value) {
-    auto result = Tensor<bool, N>(lhs.shape());
+    auto result = Tensor<bool, N>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), [] __device__(const T& x, const T& y) { return x >= y; });
     return result;
 }
@@ -334,7 +341,7 @@ Tensor<bool, N> operator>=(const Tensor<T, N>& lhs, const T value) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator>=(const T value, const Tensor<T, N>& rhs) {
-    auto result = Tensor<bool, N>(rhs.shape());
+    auto result = Tensor<bool, N>(rhs.shape(), rhs.order());
     thrust::transform(rhs.begin(), rhs.end(), thrust::make_constant_iterator(value), result.begin(), [] __device__(const T& x, const T& y) { return x <= y; });
     return result;
 }
@@ -392,8 +399,9 @@ Tensor<bool, N> operator<=(const T value, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator==(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
     auto [_lhs, _rhs] = broadcast(lhs, rhs);
-    auto result = Tensor<bool, N>(_lhs.shape());
+    auto result = Tensor<bool, N>(_lhs.shape(), _lhs.order());
     thrust::transform(_lhs.begin(), _lhs.end(), _rhs.begin(), result.begin(), [] __device__(const T& x, const T& y) { return x == y; });
     return result;
 }
@@ -409,7 +417,7 @@ Tensor<bool, N> operator==(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator==(const Tensor<T, N>& lhs, const T value) {
-    auto result = Tensor<bool, N>(lhs.shape());
+    auto result = Tensor<bool, N>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), [] __device__(const T& x, const T& y) { return x == y; });
     return result;
 }
@@ -439,8 +447,9 @@ Tensor<bool, N> operator==(const T value, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator!=(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
     auto [_lhs, _rhs] = broadcast(lhs, rhs);
-    auto result = Tensor<bool, N>(_lhs.shape());
+    auto result = Tensor<bool, N>(_lhs.shape(), _lhs.order());
     thrust::transform(_lhs.begin(), _lhs.end(), _rhs.begin(), result.begin(), [] __device__(const T& x, const T& y) { return x != y; });
     return result;
 }
@@ -456,7 +465,7 @@ Tensor<bool, N> operator!=(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<bool, N> operator!=(const Tensor<T, N>& lhs, const T value) {
-    auto result = Tensor<bool, N>(lhs.shape());
+    auto result = Tensor<bool, N>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), [] __device__(const T& x, const T& y) { return x != y; });
     return result;
 }

--- a/lib/core/slice.hpp
+++ b/lib/core/slice.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "lib/core/assertions.hpp"
 #include "lib/core/tensor.hpp"
 
 namespace vt {
@@ -97,6 +98,7 @@ class TensorSliceProxy : public Tensor<T, N> {
      * @return TensorSliceProxy: The tensor slice proxy object.
      */
     TensorSliceProxy& operator=(const Tensor<T, N>& other) {
+        assert_same_order_between_two_tensors(this->order(), other.order());
         assert(this->shape() == other.shape());
         thrust::copy(other.begin(), other.end(), this->begin());
         return *this;
@@ -162,7 +164,9 @@ class TensorCondProxy : public Tensor<T, N> {
      * @param tensor: The tensor.
      * @param cond: The condition tensor.
      */
-    TensorCondProxy(const Tensor<T, N>& tensor, const Tensor<bool, N>& cond) : Tensor<T, N>(tensor), cond(cond) {}
+    TensorCondProxy(const Tensor<T, N>& tensor, const Tensor<bool, N>& cond) : Tensor<T, N>(tensor), cond(cond) {
+        assert_same_order_between_two_tensors(this->order(), cond.order());
+    }
 
     /**
      * @brief Copy assignment operator for the TensorCondProxy from a constant.

--- a/lib/core/tests/test_iterator.cc
+++ b/lib/core/tests/test_iterator.cc
@@ -2,17 +2,32 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Iterator1D, BasicAssertions) {
+TEST(Iterator1DC, BasicAssertions) {
     auto tensor = vt::arange(12)({1, 12, 2});
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 3, 5, 7, 9, 11}));
 }
 
-TEST(Iterator2D, BasicAssertions) {
+TEST(Iterator2DC, BasicAssertions) {
     auto tensor = vt::arange(12).reshape(4, 3)({1, 3, 1}, {0, 3, 2});
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{3, 5, 6, 8}));
 }
 
-TEST(Iterator3D, BasicAssertions) {
+TEST(Iterator3DC, BasicAssertions) {
     auto tensor = vt::arange(24).reshape(4, 3, 2)({1, 3, 1}, {0, 3, 2}, {1, 2, 1});
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{7, 11, 13, 17}));
+}
+
+TEST(Iterator1DF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F)({1, 12, 2});
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 3, 5, 7, 9, 11}));
+}
+
+TEST(Iterator2DF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F).reshape(4, 3)({1, 3, 1}, {0, 3, 2});
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 2, 9, 10}));
+}
+
+TEST(Iterator3DF, BasicAssertions) {
+    auto tensor = vt::arange(24, vt::Order::F).reshape(4, 3, 2)({1, 3, 1}, {0, 3, 2}, {1, 2, 1});
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{13, 14, 21, 22}));
 }

--- a/lib/core/tests/test_operator.cc
+++ b/lib/core/tests/test_operator.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(AdditionOperator, BasicAssertions) {
+TEST(AdditionOperatorC, BasicAssertions) {
     auto tensor1 = vt::ones(12);
     auto tensor2 = vt::arange(12);
     auto tensor3 = tensor1 + tensor2;
@@ -24,10 +24,33 @@ TEST(AdditionOperator, BasicAssertions) {
     auto tensor6 = vt::arange(2).reshape(2, 1, 1);
     auto tensor7 = tensor5 + tensor6;
     EXPECT_EQ(vt::asvector(tensor7), (std::vector<float>{0, 2, 4, 6, 8, 10, 1, 3, 5, 7, 9, 11}));
-
 }
 
-TEST(SubtractionOperator, BasicAssertions) {
+TEST(AdditionOperatorF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F);
+    auto tensor2 = vt::arange(12, vt::Order::F);
+    auto tensor3 = tensor1 + tensor2;
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+
+    tensor3 = tensor1 + 1.0f;
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2}));
+
+    tensor3 = 1.0f + tensor2;
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}));
+
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+
+    auto tensor4 = tensor1[1] + tensor2[1];
+    EXPECT_EQ(vt::asvector(tensor4), (std::vector<float>{2}));
+
+    auto tensor5 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3);
+    auto tensor6 = vt::arange(2, vt::Order::F).reshape(2, 1, 1);
+    auto tensor7 = tensor5 + tensor6;    
+    EXPECT_EQ(vt::asvector(tensor7), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+}
+
+TEST(SubtractionOperatorC, BasicAssertions) {
     auto tensor1 = vt::ones(12);
     auto tensor2 = vt::arange(12);
     auto tensor3 = tensor2 - tensor1;
@@ -49,10 +72,33 @@ TEST(SubtractionOperator, BasicAssertions) {
     auto tensor6 = vt::arange(2).reshape(2, 1, 1);
     auto tensor7 = tensor5 - tensor6;
     EXPECT_EQ(vt::asvector(tensor7), (std::vector<float>{0, 2, 4, 6, 8, 10, -1, 1, 3, 5, 7, 9}));
-
 }
 
-TEST(AdditionOperatorForReshapeAndSliceTensor, BasicAssertions) {
+TEST(SubtractionOperatorF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F);
+    auto tensor2 = vt::arange(12, vt::Order::F);
+    auto tensor3 = tensor2 - tensor1;
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
+
+    tensor3 = tensor1 - 1.0f;
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+
+    tensor3 = 1.0f - tensor1;
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+
+    auto tensor4 = tensor1[1] - tensor2[1];
+    EXPECT_EQ(vt::asvector(tensor4), (std::vector<float>{0}));    
+
+    auto tensor5 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3);
+    auto tensor6 = vt::arange(2, vt::Order::F).reshape(2, 1, 1);
+    auto tensor7 = tensor5 - tensor6;
+    EXPECT_EQ(vt::asvector(tensor7), (std::vector<float>{0, -1, 2, 1, 4, 3, 6, 5, 8, 7, 10, 9}));
+}
+
+TEST(AdditionOperatorForReshapeAndSliceTensorC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3);
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -70,7 +116,25 @@ TEST(AdditionOperatorForReshapeAndSliceTensor, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 }
 
-TEST(SubtractionOperatorForReshapeAndSliceTensor, BasicAssertions) {
+TEST(AdditionOperatorForReshapeAndSliceTensorF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3);
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor3 + tensor4;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<float>{2, 3, 10, 11}));
+
+    tensor5 = tensor3 + 1.0f;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<float>{2, 2, 2, 2}));
+
+    tensor5 = 1.0f + tensor4;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<float>{2, 3, 10, 11}));
+
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+}
+
+TEST(SubtractionOperatorForReshapeAndSliceTensorC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3);
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -88,7 +152,25 @@ TEST(SubtractionOperatorForReshapeAndSliceTensor, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 }
 
-TEST(OperatorMultiply, BasicAssertions) {
+TEST(SubtractionOperatorForReshapeAndSliceTensorF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3);
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor4 - tensor3;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<float>{0, 1, 8, 9}));
+
+    tensor5 = tensor3 - 1.0f;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<float>{0, 0, 0, 0}));
+
+    tensor5 = 1.0f - tensor3;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<float>{0, 0, 0, 0}));
+
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+}
+
+TEST(OperatorMultiplyC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3) + 5.0f;
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -108,7 +190,27 @@ TEST(OperatorMultiply, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor8), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 2, 4, 6, 8, 10}));
 }
 
-TEST(OperatorDevide, BasicAssertions) {
+TEST(OperatorMultiplyF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3) + 5.0f;
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor4 * tensor3;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<float>{6, 12, 54, 60}));
+
+    tensor5 = tensor4 * 6.0f;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<float>{6, 12, 54, 60}));
+
+    tensor5 = 6.0f * tensor4;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<float>{6, 12, 54, 60}));
+
+    auto tensor6 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3);
+    auto tensor7 = vt::arange(2, vt::Order::F).reshape(2, 1, 1);
+    auto tensor8 = tensor6 * tensor7;
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<float>{0, 0, 0, 2, 0, 4, 0, 6, 0, 8, 0, 10}));
+}
+
+TEST(OperatorDevideC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3) + 5.0f;
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -139,7 +241,38 @@ TEST(OperatorDevide, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor8), (std::vector<float>{0, 0, 0, 0, 0, 0, 0.5, 0.25, 1.0f/6, 0.125, 0.1, 1.0f/12}));
 }
 
-TEST(OperatorGreaterThan, BasicAssertions) {
+TEST(OperatorDevideF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3) + 5.0f;
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor4 / tensor3;
+
+    auto vec = std::vector<float>{1, 2, 9, 10};
+    auto result = vt::asvector(tensor5);
+    for (size_t i = 0; i < vec.size(); i++) {
+        EXPECT_NEAR(result[i], vec[i] / 6.0f, 1e-6);
+    }
+
+    tensor5 = tensor4 / 6.0f;
+    result = vt::asvector(tensor5);
+    for (size_t i = 0; i < vec.size(); i++) {
+        EXPECT_NEAR(result[i], vec[i] / 6.0f, 1e-6);
+    }
+
+    tensor5 = 6.0f / tensor4;
+    result = vt::asvector(tensor5);
+    for (size_t i = 0; i < vec.size(); i++) {
+        EXPECT_NEAR(result[i], 6.0f / vec[i], 1e-6);
+    }
+
+    auto tensor6 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3) + 2.0f;
+    auto tensor7 = vt::arange(2, vt::Order::F).reshape(2, 1, 1);
+    auto tensor8 = tensor7 / tensor6;
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<float>{0, 0.5, 0, 0.25, 0, 1.f/6, 0, 0.125, 0, 0.1, 0, 1.0f/12}));
+}
+
+TEST(OperatorGreaterThanC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3) + 5.0f;
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -156,10 +289,30 @@ TEST(OperatorGreaterThan, BasicAssertions) {
     auto tensor6 = vt::arange(12)({0, 12, 2}).reshape(1, 2, 3);
     auto tensor7 = vt::arange(2).reshape(2, 1, 1) + 6.0f;
     auto tensor8 = tensor6 > tensor7;
-    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{false, false, false, false, true, true, false, false, false, false, true, true}));
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1}));
 }
 
-TEST(OperatorLessThan, BasicAssertions) {
+TEST(OperatorGreaterThanF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3) + 5.0f;
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor4 > tensor3;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{0, 0, 1, 1}));
+
+    tensor5 = tensor4 > 5.0f;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{0, 0, 1, 1}));
+
+    tensor5 = 5.0f > tensor4;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{1, 1, 0, 0}));
+
+    auto tensor6 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3);
+    auto tensor7 = vt::arange(2, vt::Order::F).reshape(2, 1, 1) + 6.0f;
+    auto tensor8 = tensor6 > tensor7;
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1}));
+}
+
+TEST(OperatorLessThanC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3) + 5.0f;
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -176,10 +329,30 @@ TEST(OperatorLessThan, BasicAssertions) {
     auto tensor6 = vt::arange(12)({0, 12, 2}).reshape(1, 2, 3);
     auto tensor7 = vt::arange(2).reshape(2, 1, 1) + 6.0f;
     auto tensor8 = tensor6 < tensor7;
-    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{true, true, true, false, false, false, true, true, true, true, false, false}));
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0}));
 }
 
-TEST(OperatorGreaterThanOrEqual, BasicAssertions) {
+TEST(OperatorLessThanF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3) + 5.0f;
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor4 < tensor3;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{1, 1, 0, 0}));
+
+    tensor5 = tensor4 < 5.0f;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{1, 1, 0, 0}));
+
+    tensor5 = 5.0f < tensor4;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{0, 0, 1, 1}));
+
+    auto tensor6 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3);
+    auto tensor7 = vt::arange(2, vt::Order::F).reshape(2, 1, 1) + 6.0f;
+    auto tensor8 = tensor6 < tensor7;
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{1, 1, 1, 1, 1, 1, 0, 1, 0, 0, 0, 0}));
+}
+
+TEST(OperatorGreaterThanOrEqualC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3) + 5.0f;
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -196,10 +369,30 @@ TEST(OperatorGreaterThanOrEqual, BasicAssertions) {
     auto tensor6 = vt::arange(12)({0, 12, 2}).reshape(1, 2, 3);
     auto tensor7 = vt::arange(2).reshape(2, 1, 1) + 6.0f;
     auto tensor8 = tensor6 >= tensor7;
-    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{false, false, false, true, true, true, false, false, false, false, true, true}));
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1}));
 }
 
-TEST(OperatorLessThanOrEqual, BasicAssertions) {
+TEST(OperatorGreaterThanOrEqualF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3) + 5.0f;
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor4 >= tensor3;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{0, 0, 1, 1}));
+
+    tensor5 = tensor4 >= 5.0f;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{0, 0, 1, 1}));
+
+    tensor5 = 5.0f >= tensor4;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{1, 1, 0, 0}));
+
+    auto tensor6 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3);
+    auto tensor7 = vt::arange(2, vt::Order::F).reshape(2, 1, 1) + 6.0f;
+    auto tensor8 = tensor6 >= tensor7;
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{0, 0, 0, 0, 0, 0, 1, 0, 1, 1, 1, 1}));
+}
+
+TEST(OperatorLessThanOrEqualC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3) + 5.0f;
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -216,10 +409,30 @@ TEST(OperatorLessThanOrEqual, BasicAssertions) {
     auto tensor6 = vt::arange(12)({0, 12, 2}).reshape(1, 2, 3);
     auto tensor7 = vt::arange(2).reshape(2, 1, 1) + 6.0f;
     auto tensor8 = tensor6 <= tensor7;
-    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{true, true, true, true, false, false, true, true, true, true, false, false}));
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 0, 0}));
 }
 
-TEST(OperatorEqual, BasicAssertions) {
+TEST(OperatorLessThanOrEqualF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3) + 5.0f;
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor4 <= tensor3;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{1, 1, 0, 0}));
+
+    tensor5 = tensor4 <= 5.0f;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{1, 1, 0, 0}));
+
+    tensor5 = 5.0f <= tensor4;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{0, 0, 1, 1}));
+
+    auto tensor6 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3);
+    auto tensor7 = vt::arange(2, vt::Order::F).reshape(2, 1, 1) + 6.0f;
+    auto tensor8 = tensor6 <= tensor7;
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0}));
+}
+
+TEST(OperatorEqualC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3) + 5.0f;
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -236,10 +449,30 @@ TEST(OperatorEqual, BasicAssertions) {
     auto tensor6 = vt::arange(12)({0, 12, 2}).reshape(1, 2, 3);
     auto tensor7 = vt::arange(2).reshape(2, 1, 1) + 6.0f;
     auto tensor8 = tensor6 == tensor7;
-    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{false, false, false, true, false, false, false, false, false, false, false, false}));
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0}));
 }
 
-TEST(OperatorNotEqual, BasicAssertions) {
+TEST(OperatorEqualF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3) + 1.0f;
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor4 == tensor3;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{0, 1, 0, 0}));
+
+    tensor5 = tensor4 == 2.0f;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{0, 1, 0, 0}));
+
+    tensor5 = 2.0f == tensor4;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{0, 1, 0, 0}));
+
+    auto tensor6 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3);
+    auto tensor7 = vt::arange(2, vt::Order::F).reshape(2, 1, 1) + 6.0f;
+    auto tensor8 = tensor6 == tensor7;
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0}));
+}
+
+TEST(OperatorNotEqualC, BasicAssertions) {
     auto tensor1 = vt::ones(12).reshape(4, 3) + 5.0f;
     auto tensor2 = vt::arange(12).reshape(4, 3);
     auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
@@ -256,5 +489,25 @@ TEST(OperatorNotEqual, BasicAssertions) {
     auto tensor6 = vt::arange(12)({0, 12, 2}).reshape(1, 2, 3);
     auto tensor7 = vt::arange(2).reshape(2, 1, 1) + 6.0f;
     auto tensor8 = tensor6 != tensor7;
-    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{true, true, true, false, true, true, true, true, true, true, true, true}));
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1}));
+}
+
+TEST(OperatorNotEqualF, BasicAssertions) {
+    auto tensor1 = vt::ones(12, vt::Order::F).reshape(4, 3) + 1.0f;
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor3 = tensor1({1, 3, 1}, {0, 3, 2});
+    auto tensor4 = tensor2({1, 3, 1}, {0, 3, 2});
+    auto tensor5 = tensor4 != tensor3;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{1, 0, 1, 1}));
+
+    tensor5 = tensor4 != 2.0f;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{1, 0, 1, 1}));
+
+    tensor5 = 2.0f != tensor4;
+    EXPECT_EQ(vt::asvector(tensor5), (std::vector<bool>{1, 0, 1, 1}));
+
+    auto tensor6 = vt::arange(12, vt::Order::F)({0, 12, 2}).reshape(1, 2, 3);
+    auto tensor7 = vt::arange(2, vt::Order::F).reshape(2, 1, 1) + 6.0f;
+    auto tensor8 = tensor6 != tensor7;
+    EXPECT_EQ(vt::asvector(tensor8), (std::vector<bool>{1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1}));
 }

--- a/lib/core/tests/test_slice.cc
+++ b/lib/core/tests/test_slice.cc
@@ -19,27 +19,51 @@ TEST(SliceConstructor, BasicAssertions) {
     EXPECT_EQ(s.step, 2);
 }
 
-TEST(Slice1DTensor, BasicAssertions) {
+TEST(Slice1DTensorC, BasicAssertions) {
     auto tensor = vt::arange(12);
     auto tensor1 = tensor({1, 10, 2});
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 3, 5, 7, 9}));
     EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(tensor1.contiguous(), false);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.size(), 5);
 }
 
-TEST(Slice2DTensor, BasicAssertions) {
+TEST(Slice1DTensorF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F);
+    auto tensor1 = tensor({1, 10, 2});
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 3, 5, 7, 9}));
+    EXPECT_EQ(tensor.contiguous(), true);
+    EXPECT_EQ(tensor1.contiguous(), false);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.size(), 5);
+}
+
+TEST(Slice2DTensorC, BasicAssertions) {
     auto tensor = vt::arange(12).reshape(4, 3);
     auto tensor1 = tensor({1, 3, 1}, {0, 3, 2});
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{3, 5, 6, 8}));
     EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(tensor1.contiguous(), false);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.size(), 4);
 }
 
-TEST(SliceAndAssigmentFromTensor, BasicAssertions) {
+TEST(Slice2DTensorF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F).reshape(4, 3);
+    auto tensor1 = tensor({1, 3, 1}, {0, 3, 2});
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 2, 9, 10}));
+    EXPECT_EQ(tensor.contiguous(), true);
+    EXPECT_EQ(tensor1.contiguous(), false);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.size(), 4);
+}
+
+TEST(SliceAndAssigmentFromTensorC, BasicAssertions) {
     auto tensor1 = vt::ones(4, 3);
     auto tensor2 = vt::arange(12).reshape(4, 3);
     vt::Tensor tensor3 = tensor2({1, 3, 1}, {0, 3, 2});
@@ -53,7 +77,21 @@ TEST(SliceAndAssigmentFromTensor, BasicAssertions) {
     EXPECT_EQ(tensor3.size(), 4);
 }
 
-TEST(SliceAndAssigmentFromProxy, BasicAssertions) {
+TEST(SliceAndAssigmentFromTensorF, BasicAssertions) {
+    auto tensor1 = vt::ones(4, 3, vt::Order::F);
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    vt::Tensor tensor3 = tensor2({1, 3, 1}, {0, 3, 2});
+    tensor1({1, 3, 1}, {0, 3, 2}) = tensor3;
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 2, 1, 1, 1, 1, 1, 1, 9, 10, 1}));
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{1, 2, 9, 10}));
+    EXPECT_EQ(tensor1.contiguous(), true);
+    EXPECT_EQ(tensor2.contiguous(), true);
+    EXPECT_EQ(tensor3.contiguous(), false);
+    EXPECT_EQ(tensor3.size(), 4);
+}
+
+TEST(SliceAndAssigmentFromProxyC, BasicAssertions) {
     auto tensor1 = vt::ones(4, 3);
     auto tensor2 = vt::arange(12).reshape(4, 3);
     tensor1({1, 3, 1}, {0, 3, 2}) = tensor2({1, 3, 1}, {0, 3, 2});
@@ -63,15 +101,38 @@ TEST(SliceAndAssigmentFromProxy, BasicAssertions) {
     EXPECT_EQ(tensor2.contiguous(), true);
 }
 
-TEST(SliceAndAssigmentFromConstant, BasicAssertions) {
+TEST(SliceAndAssigmentFromProxyF, BasicAssertions) {
+    auto tensor1 = vt::ones(4, 3, vt::Order::F);
+    auto tensor2 = vt::arange(12, vt::Order::F).reshape(4, 3);
+    tensor1({1, 3, 1}, {0, 3, 2}) = tensor2({1, 3, 1}, {0, 3, 2});
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 2, 1, 1, 1, 1, 1, 1, 9, 10, 1}));
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(tensor1.contiguous(), true);
+    EXPECT_EQ(tensor2.contiguous(), true);
+}
+
+TEST(SliceAndAssigmentFromConstantC, BasicAssertions) {
     auto tensor1 = vt::ones(4, 3);
     tensor1({1, 3, 1}, {0, 3, 2}) = 2;
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 2, 1, 2, 2, 1, 2, 1, 1, 1}));
     EXPECT_EQ(tensor1.contiguous(), true);
 }
 
-TEST(TensorCondProxyFromConstant, BasicAssertions) {
+TEST(SliceAndAssigmentFromConstantF, BasicAssertions) {
+    auto tensor1 = vt::ones(4, 3, vt::Order::F);
+    tensor1({1, 3, 1}, {0, 3, 2}) = 2;
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 2, 2, 1, 1, 1, 1, 1, 1, 2, 2, 1}));
+    EXPECT_EQ(tensor1.contiguous(), true);
+}
+
+TEST(TensorCondProxyFromConstantC, BasicAssertions) {
     auto tensor = vt::arange(24)({0, 24, 2}).reshape(3, 4);
+    tensor[tensor > 12.0f] = 1.0f;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 1, 1, 1, 1, 1}));
+}
+
+TEST(TensorCondProxyFromConstantF, BasicAssertions) {
+    auto tensor = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(3, 4);
     tensor[tensor > 12.0f] = 1.0f;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 1, 1, 1, 1, 1}));
 }

--- a/lib/core/tests/test_tensor.cc
+++ b/lib/core/tests/test_tensor.cc
@@ -4,100 +4,158 @@
 
 TEST(HelperFunctions, BasicAssertions) {
     auto shape = vt::Shape<3>{1, 2, 3};
-    auto stides = vt::get_strides(shape);
+    auto strides = vt::get_strides(shape, vt::Order::C);
     auto size = vt::get_size(shape);
     auto expanded_shape = vt::expand_shape(shape, 4, 5, 6);
     EXPECT_EQ(size, 6);
-    EXPECT_EQ(stides[0], 6);
-    EXPECT_EQ(stides[1], 3);
-    EXPECT_EQ(stides[2], 1);
-    for (size_t i = 0; i < 6; i++) {
-        EXPECT_EQ(expanded_shape[i], i + 1);
-    }
+    EXPECT_EQ(strides, (vt::Shape<3>{6, 3, 1}));
+    EXPECT_EQ(expanded_shape, (vt::Shape<6>{1, 2, 3, 4, 5, 6}));
+
+    // Test for F order
+    strides = vt::get_strides(shape, vt::Order::F);
+    EXPECT_EQ(strides, (vt::Shape<3>{1, 1, 2}));
 
     // Test for 0D tensor.
     auto shape1 = vt::Shape<0>{};
-    auto stides1 = vt::get_strides(shape1);
+    auto strides1 = vt::get_strides(shape1, vt::Order::C);
     auto size1 = vt::get_size(shape1);
     auto expanded_shape1 = vt::expand_shape(shape1, 1, 2, 3);
     EXPECT_EQ(size1, 1);
-    for (size_t i = 0; i < 3; i++) {
-        EXPECT_EQ(expanded_shape1[i], i + 1);
-    }
+    EXPECT_EQ(expanded_shape1, (vt::Shape<3>{1, 2, 3}));
 }
 
-TEST(TensorConstructor, BasicAssertions) {
+TEST(TensorConstructorC, BasicAssertions) {
     using vector_type = vt::Tensor<float, 1>::vector_type;
 
     auto shape = vt::Shape<3>{1, 2, 3};
-    auto tensor = vt::Tensor<float, 3>(shape);
+    auto tensor = vt::Tensor<float, 3>(shape, vt::Order::C);
     EXPECT_EQ(tensor.size(), 6);
     EXPECT_EQ(tensor.shape(), (vt::Shape<3>{1, 2, 3}));
     EXPECT_EQ(tensor.strides(), (vt::Shape<3>{6, 3, 1}));
     EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::C);
     EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 0, 0, 0, 0, 0}));
 
     vector_type data(6, 1);
-    auto tensor1 = vt::Tensor<float, 3>(std::make_shared<vector_type>(data), shape);
+    auto tensor1 = vt::Tensor<float, 3>(std::make_shared<vector_type>(data), shape, vt::Order::C);
     EXPECT_EQ(tensor1.size(), 6);
     EXPECT_EQ(tensor1.shape(), (vt::Shape<3>{1, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (vt::Shape<3>{6, 3, 1}));
     EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 1, 1, 1}));
 
     auto shape2 = vt::Shape<1>{5};
     auto strides2 = vt::Shape<1>{1};
-    auto tensor2 = vt::Tensor<float, 1>(std::make_shared<vector_type>(data), shape2, strides2, 1, true);
+    auto tensor2 = vt::Tensor<float, 1>(std::make_shared<vector_type>(data), shape2, strides2, 1, vt::Order::C, true);
     EXPECT_EQ(tensor2.size(), 5);
     EXPECT_EQ(tensor2.shape(), (vt::Shape<1>{5}));
     EXPECT_EQ(tensor2.strides(), (vt::Shape<1>{1}));
     EXPECT_EQ(tensor2.start(), 1);
+    EXPECT_EQ(tensor2.order(), vt::Order::C);
     EXPECT_EQ(tensor2.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{1, 1, 1, 1, 1}));
 
     // Test for 0D tensor.
-    auto tensor3 = vt::Tensor<float, 0>(vt::Shape<0>{});
+    auto tensor3 = vt::Tensor<float, 0>(vt::Shape<0>{}, vt::Order::C);
     EXPECT_EQ(tensor3.size(), 1);
     EXPECT_EQ(tensor3.shape(), (vt::Shape<0>{}));
     EXPECT_EQ(tensor3.strides(), (vt::Shape<0>{}));
     EXPECT_EQ(tensor3.start(), 0);
+    EXPECT_EQ(tensor3.order(), vt::Order::C);
     EXPECT_EQ(tensor3.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0}));
 }
 
-TEST(TensorReshape, BasicAssertions) {
+TEST(TensorConstructorF, BasicAssertions) {
+    auto shape = vt::Shape<3>{1, 2, 3};
+    auto tensor = vt::Tensor<float, 3>(shape, vt::Order::F);
+    EXPECT_EQ(tensor.size(), 6);
+    EXPECT_EQ(tensor.shape(), (vt::Shape<3>{1, 2, 3}));
+    EXPECT_EQ(tensor.strides(), (vt::Shape<3>{1, 1, 2}));
+    EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::F);
+    EXPECT_EQ(tensor.contiguous(), true);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 0, 0, 0, 0, 0}));
+
+    // Test for 0D tensor.
+    auto tensor1 = vt::Tensor<float, 0>(vt::Shape<0>{}, vt::Order::F);
+    EXPECT_EQ(tensor1.size(), 1);
+    EXPECT_EQ(tensor1.shape(), (vt::Shape<0>{}));
+    EXPECT_EQ(tensor1.strides(), (vt::Shape<0>{}));
+    EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.contiguous(), true);
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0}));
+}
+
+TEST(TensorReshapeC, BasicAssertions) {
     auto tensor = vt::arange(6).reshape(1, 2, 3);
     EXPECT_EQ(tensor.size(), 6);
     EXPECT_EQ(tensor.shape(), (vt::Shape<3>{1, 2, 3}));
     EXPECT_EQ(tensor.strides(), (vt::Shape<3>{6, 3, 1}));
     EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::C);
     EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5}));
 
     // Test for 0D tensor.
-    auto tensor1 = vt::Tensor<float, 0>(vt::Shape<0>{}).reshape(1, 1);
+    auto tensor1 = vt::Tensor<float, 0>(vt::Shape<0>{}, vt::Order::C).reshape(1, 1);
     EXPECT_EQ(tensor1.size(), 1);
     EXPECT_EQ(tensor1.shape(), (vt::Shape<2>{1, 1}));
     EXPECT_EQ(tensor1.strides(), (vt::Shape<2>{1, 1}));
     EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.contiguous(), true);
-
 }
 
-TEST(SlicedTensorReshape, BasicAssertions) {
+TEST(TensorReshapeF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F).reshape(1, 2, 3);
+    EXPECT_EQ(tensor.size(), 6);
+    EXPECT_EQ(tensor.shape(), (vt::Shape<3>{1, 2, 3}));
+    EXPECT_EQ(tensor.strides(), (vt::Shape<3>{1, 1, 2}));
+    EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::F);
+    EXPECT_EQ(tensor.contiguous(), true);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5}));
+
+    // Test for 0D tensor.
+    auto tensor1 = vt::Tensor<float, 0>(vt::Shape<0>{}, vt::Order::F).reshape(1, 1);
+    EXPECT_EQ(tensor1.size(), 1);
+    EXPECT_EQ(tensor1.shape(), (vt::Shape<2>{1, 1}));
+    EXPECT_EQ(tensor1.strides(), (vt::Shape<2>{1, 1}));
+    EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.contiguous(), true);
+}
+
+TEST(SlicedTensorReshapeC, BasicAssertions) {
     auto tensor = vt::arange(12)({0, 12, 2});
     auto tensor1 = tensor.reshape(1, 2, 3);
     EXPECT_EQ(tensor.size(), 6);
     EXPECT_EQ(tensor1.shape(), (vt::Shape<3>{1, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (vt::Shape<3>{6, 3, 1}));
     EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.contiguous(), true);
-    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 2, 4, 6, 8, 10}));
 }
 
-TEST(TensorInPlacePlusScalar, BasicAssertions) {
+TEST(SlicedTensorReshapeF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F)({0, 12, 2});
+    auto tensor1 = tensor.reshape(1, 2, 3);
+    EXPECT_EQ(tensor.size(), 6);
+    EXPECT_EQ(tensor1.shape(), (vt::Shape<3>{1, 2, 3}));
+    EXPECT_EQ(tensor1.strides(), (vt::Shape<3>{1, 1, 2}));
+    EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.contiguous(), true);
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 2, 4, 6, 8, 10}));
+}
+
+TEST(TensorInPlacePlusScalarC, BasicAssertions) {
     auto tensor = vt::arange(6);
     tensor += 1;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 2, 3, 4, 5, 6}));
@@ -108,7 +166,18 @@ TEST(TensorInPlacePlusScalar, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{3}));
 }
 
-TEST(TensorInPlaceMinusScalar, BasicAssertions) {
+TEST(TensorInPlacePlusScalarF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F);
+    tensor += 1;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 2, 3, 4, 5, 6}));
+
+    // Test for 0D tensor.
+    auto tensor1 = tensor[1];
+    tensor1 += 1;
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{3}));
+}
+
+TEST(TensorInPlaceMinusScalarC, BasicAssertions) {
     auto tensor = vt::arange(6);
     tensor -= 1;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{-1, 0, 1, 2, 3, 4}));
@@ -119,7 +188,18 @@ TEST(TensorInPlaceMinusScalar, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{-1}));
 }
 
-TEST(TensorInPlaceMultiplyScalar, BasicAssertions) {
+TEST(TensorInPlaceMinusScalarF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F);
+    tensor -= 1;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{-1, 0, 1, 2, 3, 4}));
+
+    // Test for 0D tensor.
+    auto tensor1 = tensor[1];
+    tensor1 -= 1;
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{-1}));
+}
+
+TEST(TensorInPlaceMultiplyScalarC, BasicAssertions) {
     auto tensor = vt::arange(6);
     tensor *= 2.0f;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10}));
@@ -130,7 +210,18 @@ TEST(TensorInPlaceMultiplyScalar, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{4}));
 }
 
-TEST(TensorInPlaceDivideScalar, BasicAssertions) {
+TEST(TensorInPlaceMultiplyScalarF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F);
+    tensor *= 2.0f;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10}));
+
+    // Test for 0D tensor.
+    auto tensor1 = tensor[1];
+    tensor1 *= 2.0f;
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{4}));
+}
+
+TEST(TensorInPlaceDivideScalarC, BasicAssertions) {
     auto tensor = vt::arange(6) * 2.0f;
     tensor /= 2.0f;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5}));
@@ -141,45 +232,117 @@ TEST(TensorInPlaceDivideScalar, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0.5}));
 }
 
-TEST(TensorInPlacePlusTensor, BasicAssertions) {
+TEST(TensorInPlaceDivideScalarF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F) * 2.0f;
+    tensor /= 2.0f;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5}));
+
+    // Test for 0D tensor.
+    auto tensor1 = tensor[1];
+    tensor1 /= 2.0f;
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0.5}));
+}
+
+TEST(TensorInPlacePlusTensorC, BasicAssertions) {
     auto tensor = vt::arange(6);
     auto tensor1 = vt::arange(6);
     tensor += tensor1;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2, 3, 4, 5}));
 
+    // Test for 0D tensor.
     auto tensor2 = tensor[1] + tensor1[1];
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{3}));
 }
 
-TEST(TensorInPlaceMinusTensor, BasicAssertions) {
+TEST(TensorInPlacePlusTensorF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F);
+    auto tensor1 = vt::arange(6, vt::Order::F);
+    tensor += tensor1;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2, 3, 4, 5}));
+
+    // Test for 0D tensor.
+    auto tensor2 = tensor[1] + tensor1[1];
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{3}));
+}
+
+
+TEST(TensorInPlaceMinusTensorC, BasicAssertions) {
     auto tensor = vt::arange(6);
     auto tensor1 = vt::arange(6);
     tensor -= tensor1;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 0, 0, 0, 0, 0}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2, 3, 4, 5}));
 
+    // Test for 0D tensor.
+    auto tensor2 = tensor[1] - tensor1[1];
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{-1}));
+
+    // Test for F order
+    auto tensor3 = vt::arange(6, vt::Order::F);
+    auto tensor4 = vt::arange(6, vt::Order::F);
+    tensor3 -= tensor4;
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0, 0, 0, 0, 0, 0}));
+    EXPECT_EQ(vt::asvector(tensor4), (std::vector<float>{0, 1, 2, 3, 4, 5}));
+}
+
+TEST(TensorInPlaceMinusTensorF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F);
+    auto tensor1 = vt::arange(6, vt::Order::F);
+    tensor -= tensor1;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 0, 0, 0, 0, 0}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2, 3, 4, 5}));
+
+    // Test for 0D tensor.
     auto tensor2 = tensor[1] - tensor1[1];
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{-1}));
 }
 
-TEST(TensorInPlaceMultiplyTensor, BasicAssertions) {
+TEST(TensorInPlaceMultiplyTensorC, BasicAssertions) {
     auto tensor = vt::arange(6);
     auto tensor1 = vt::arange(6);
     tensor *= tensor1;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 4, 9, 16, 25}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2, 3, 4, 5}));
 
+    // Test for 0D tensor.
     auto tensor2 = tensor[1] * tensor1[1];
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{1}));
 }
 
-TEST(TensorInPlaceDivideTensor, BasicAssertions) {
+TEST(TensorInPlaceMultiplyTensorF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F);
+    auto tensor1 = vt::arange(6, vt::Order::F);
+    tensor *= tensor1;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 4, 9, 16, 25}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2, 3, 4, 5}));
+
+    // Test for 0D tensor.
+    auto tensor2 = tensor[1] * tensor1[1];
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{1}));
+}
+
+TEST(TensorInPlaceDivideTensorC, BasicAssertions) {
     auto tensor = (vt::arange(6) + 1.0f) * 2.0f;
     auto tensor1 = vt::arange(6) + 1.0f;
     tensor /= tensor1;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{2, 2, 2, 2, 2, 2}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 2, 3, 4, 5, 6}));
+
+    // Test for 0D tensor.
+    auto tensor2 = tensor[1] / tensor1[1];
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{1}));
+}
+
+TEST(TensorInPlaceDivideTensorF, BasicAssertions) {
+    auto tensor = (vt::arange(6, vt::Order::F) + 1.0f) * 2.0f;
+    auto tensor1 = vt::arange(6, vt::Order::F) + 1.0f;
+    tensor /= tensor1;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{2, 2, 2, 2, 2, 2}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 2, 3, 4, 5, 6}));
+
+    // Test for 0D tensor.
     auto tensor2 = tensor[1] / tensor1[1];
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{1}));
 }
@@ -194,7 +357,7 @@ TEST(TensorIterator, BasicAssertions) {
     for (; it != end; ++it, ++index) EXPECT_EQ(*it, index);
 }
 
-TEST(TensorSliceOperation, BasicAssertions) {
+TEST(TensorSliceOperationC, BasicAssertions) {
     auto tensor1 = vt::zeros(2);
     tensor1(vt::Slice(0, 2, 1));
     tensor1({0, 2, 1});
@@ -212,7 +375,25 @@ TEST(TensorSliceOperation, BasicAssertions) {
     tensor4(slices);
 }
 
-TEST(TensorEllipsisSlices, BasicAssertions){
+TEST(TensorSliceOperationF, BasicAssertions) {
+    auto tensor1 = vt::zeros(2, vt::Order::F);
+    tensor1(vt::Slice(0, 2, 1));
+    tensor1({0, 2, 1});
+
+    auto tensor2 = vt::zeros(2, 2, vt::Order::F);
+    tensor2(vt::Slice(0, 2, 1), vt::Slice(0, 2, 1));
+    tensor2({0, 2, 1}, {0, 2, 1});
+
+    auto tensor3 = vt::zeros(vt::Shape<3>{2, 2, 2}, vt::Order::F);
+    tensor3(vt::Slice(0, 2, 1), vt::Slice(0, 2, 1), vt::Slice(0, 2, 1));
+    tensor3({0, 2, 1}, {0, 2, 1}, {0, 2, 1});
+
+    auto tensor4 = vt::zeros(vt::Shape<3>{2, 2, 2}, vt::Order::F);
+    std::array<vt::Slice, 3> slices = {vt::Slice(0, 2, 1), vt::Slice(0, 2, 1), vt::Slice(0, 2, 1)};
+    tensor4(slices);
+}
+
+TEST(TensorEllipsisSlicesC, BasicAssertions){
     auto tensor = vt::arange(12).reshape(2, 2, 3);
     tensor = tensor(vt::ellipsis, {0, 2});
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 3, 4, 6, 7, 9, 10}));
@@ -220,10 +401,19 @@ TEST(TensorEllipsisSlices, BasicAssertions){
     auto tensor1 = vt::arange(12);
     tensor1 = tensor1(vt::ellipsis, {0, 2});
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1}));
-
 }
 
-TEST(TensorSliceAlongTheAxisOperation, BasicAssertions) {
+TEST(TensorEllipsisSlicesF, BasicAssertions){
+    auto tensor = vt::arange(12, vt::Order::F).reshape(2, 2, 3);
+    tensor = tensor(vt::ellipsis, {0, 2});
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7}));
+
+    auto tensor1 = vt::arange(12, vt::Order::F);
+    tensor1 = tensor1(vt::ellipsis, {0, 2});
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1}));
+}
+
+TEST(TensorSliceAlongTheAxisOperationC, BasicAssertions) {
     auto tensor = vt::arange(12).reshape(2, 2, 3);
     EXPECT_EQ(vt::asvector(tensor[0]), (std::vector<float>{0, 1, 2, 3, 4, 5}));
     EXPECT_EQ(vt::asvector(tensor[1]), (std::vector<float>{6, 7, 8, 9, 10, 11}));
@@ -232,7 +422,16 @@ TEST(TensorSliceAlongTheAxisOperation, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor1[5]), (std::vector<float>{5}));
 }
 
-TEST(TensorApplySlices, BasicAssertions) {
+TEST(TensorSliceAlongTheAxisOperationF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F).reshape(2, 2, 3);
+    EXPECT_EQ(vt::asvector(tensor[0]), (std::vector<float>{0, 2, 4, 6, 8, 10}));
+    EXPECT_EQ(vt::asvector(tensor[1]), (std::vector<float>{1, 3, 5, 7, 9, 11}));
+
+    auto tensor1 = vt::arange(12);
+    EXPECT_EQ(vt::asvector(tensor1[5]), (std::vector<float>{5}));
+}
+
+TEST(TensorApplySlicesC, BasicAssertions) {
     auto tensor1 = vt::arange(12);
     std::array<vt::Slice, 1> slices = {vt::Slice(0, 12, 2)};
     auto tensor2 = tensor1.apply_slices(slices);
@@ -241,10 +440,24 @@ TEST(TensorApplySlices, BasicAssertions) {
     EXPECT_EQ(tensor2.shape(), (vt::Shape<1>{6}));
     EXPECT_EQ(tensor2.strides(), (vt::Shape<1>{2}));
     EXPECT_EQ(tensor2.start(), 0);
+    EXPECT_EQ(tensor2.order(), vt::Order::C);
     EXPECT_EQ(tensor2.contiguous(), false);
 }
 
-TEST(TensorNewAxisAtFirstAxis, BasicAssertions){
+TEST(TensorApplySlicesF, BasicAssertions) {
+    auto tensor1 = vt::arange(12, vt::Order::F);
+    std::array<vt::Slice, 1> slices = {vt::Slice(0, 12, 2)};
+    auto tensor2 = tensor1.apply_slices(slices);
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 2, 4, 6, 8, 10}));
+    EXPECT_EQ(tensor2.size(), 6);
+    EXPECT_EQ(tensor2.shape(), (vt::Shape<1>{6}));
+    EXPECT_EQ(tensor2.strides(), (vt::Shape<1>{2}));
+    EXPECT_EQ(tensor2.start(), 0);
+    EXPECT_EQ(tensor2.order(), vt::Order::F);
+    EXPECT_EQ(tensor2.contiguous(), false);
+}
+
+TEST(TensorNewAxisAtFirstAxisC, BasicAssertions){
     auto tensor = vt::arange(24)({0, 24, 2}).reshape(3, 4);
     auto tensor1 = tensor(vt::newaxis, vt::ellipsis);
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22}));
@@ -252,20 +465,45 @@ TEST(TensorNewAxisAtFirstAxis, BasicAssertions){
     EXPECT_EQ(tensor1.shape(), (vt::Shape<3>{1, 3, 4}));
     EXPECT_EQ(tensor1.strides(), (vt::Shape<3>{0, 4, 1}));
     EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.contiguous(), false);
 
     // Test for 0D tensor.
-    auto tensor2 = vt::Tensor<float, 0>(vt::Shape<0>{});
+    auto tensor2 = vt::Tensor<float, 0>(vt::Shape<0>{}, vt::Order::C);
     auto tensor3 = tensor2(vt::newaxis, vt::ellipsis);
     EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0}));
     EXPECT_EQ(tensor3.size(), 1);
     EXPECT_EQ(tensor3.shape(), (vt::Shape<1>{1}));
     EXPECT_EQ(tensor3.strides(), (vt::Shape<1>{0}));
     EXPECT_EQ(tensor3.start(), 0);
+    EXPECT_EQ(tensor3.order(), vt::Order::C);
     EXPECT_EQ(tensor3.contiguous(), false);
 }
 
-TEST(TensorNewAxisAtLastAxis, BasicAssertions){
+TEST(TensorNewAxisAtFirstAxisF, BasicAssertions){
+    auto tensor = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(3, 4);
+    auto tensor1 = tensor(vt::newaxis, vt::ellipsis);
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22}));
+    EXPECT_EQ(tensor1.size(), 12);
+    EXPECT_EQ(tensor1.shape(), (vt::Shape<3>{1, 3, 4}));
+    EXPECT_EQ(tensor1.strides(), (vt::Shape<3>{0, 1, 3}));
+    EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.contiguous(), false);
+
+    // Test for 0D tensor.
+    auto tensor2 = vt::Tensor<float, 0>(vt::Shape<0>{}, vt::Order::F);
+    auto tensor3 = tensor2(vt::newaxis, vt::ellipsis);
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0}));
+    EXPECT_EQ(tensor3.size(), 1);
+    EXPECT_EQ(tensor3.shape(), (vt::Shape<1>{1}));
+    EXPECT_EQ(tensor3.strides(), (vt::Shape<1>{0}));
+    EXPECT_EQ(tensor3.start(), 0);
+    EXPECT_EQ(tensor3.order(), vt::Order::F);
+    EXPECT_EQ(tensor3.contiguous(), false);
+}
+
+TEST(TensorNewAxisAtLastAxisC, BasicAssertions){
     auto tensor = vt::arange(24)({0, 24, 2}).reshape(3, 4);
     auto tensor1 = tensor(vt::ellipsis, vt::newaxis);
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22}));
@@ -273,27 +511,64 @@ TEST(TensorNewAxisAtLastAxis, BasicAssertions){
     EXPECT_EQ(tensor1.shape(), (vt::Shape<3>{3, 4, 1}));
     EXPECT_EQ(tensor1.strides(), (vt::Shape<3>{4, 1, 0}));
     EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.contiguous(), false);
 
     // Test for 0D tensor.
-    auto tensor2 = vt::Tensor<float, 0>(vt::Shape<0>{});
+    auto tensor2 = vt::Tensor<float, 0>(vt::Shape<0>{}, vt::Order::C);
     auto tensor3 = tensor2(vt::ellipsis, vt::newaxis);
     EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0}));
     EXPECT_EQ(tensor3.size(), 1);
     EXPECT_EQ(tensor3.shape(), (vt::Shape<1>{1}));
     EXPECT_EQ(tensor3.strides(), (vt::Shape<1>{0}));
     EXPECT_EQ(tensor3.start(), 0);
+    EXPECT_EQ(tensor3.order(), vt::Order::C);
     EXPECT_EQ(tensor3.contiguous(), false);
 }
 
-TEST(TensorIndexWithCond, BasicAssertions){
+TEST(TensorNewAxisAtLastAxisF, BasicAssertions){
+    auto tensor = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(3, 4);
+    auto tensor1 = tensor(vt::ellipsis, vt::newaxis);
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22}));
+    EXPECT_EQ(tensor1.size(), 12);
+    EXPECT_EQ(tensor1.shape(), (vt::Shape<3>{3, 4, 1}));
+    EXPECT_EQ(tensor1.strides(), (vt::Shape<3>{1, 3, 0}));
+    EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.contiguous(), false);
+
+    // Test for 0D tensor.
+    auto tensor2 = vt::Tensor<float, 0>(vt::Shape<0>{}, vt::Order::F);
+    auto tensor3 = tensor2(vt::ellipsis, vt::newaxis);
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0}));
+    EXPECT_EQ(tensor3.size(), 1);
+    EXPECT_EQ(tensor3.shape(), (vt::Shape<1>{1}));
+    EXPECT_EQ(tensor3.strides(), (vt::Shape<1>{0}));
+    EXPECT_EQ(tensor3.start(), 0);
+    EXPECT_EQ(tensor3.order(), vt::Order::F);
+    EXPECT_EQ(tensor3.contiguous(), false);
+}
+
+TEST(TensorIndexWithCondC, BasicAssertions){
     auto tensor = vt::arange(24)({0, 24, 2}).reshape(3, 4);
     tensor[tensor > 12.0f] = 1.0f;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 1, 1, 1, 1, 1}));
 }
 
-TEST(TensorAstype, BasicAssertions){
+TEST(TensorIndexWithCondF, BasicAssertions){
+    auto tensor = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(3, 4);
+    tensor[tensor > 12.0f] = 1.0f;
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 1, 1, 1, 1, 1}));
+}
+
+TEST(TensorAstypeC, BasicAssertions){
     auto tensor = vt::arange<int>(3);
+    auto tensor1 = tensor.astype<float>();
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2}));
+}
+
+TEST(TensorAstypeF, BasicAssertions){
+    auto tensor = vt::arange<int>(3, vt::Order::F);
     auto tensor1 = tensor.astype<float>();
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 1, 2}));
 }

--- a/lib/generator/arange.hpp
+++ b/lib/generator/arange.hpp
@@ -12,12 +12,13 @@ namespace vt {
  *
  * @tparam T: Data type of the tensor.
  * @param step: The size of the tensor.
+ * @param order: The order of the tensor.
  * @return Tensor: The new tensor object.
  */
 template <typename T = float>
-Tensor<T, 1> arange(int step) {
+Tensor<T, 1> arange(int step, const Order order = Order::C) {
     assert(step > 0);
-    auto tensor = zeros<T>(step);
+    auto tensor = zeros<T>(step, order);
     thrust::sequence(tensor.begin(), tensor.end());
     return tensor;
 }
@@ -29,13 +30,14 @@ Tensor<T, 1> arange(int step) {
  * @param start: The starting value of the sequence.
  * @param end: The end value of the sequence.
  * @param step: The step size of the sequence.
+ * @param order: The order of the tensor.
  * @return Tensor<T, 1>: The new tensor object.
  */
 template <typename T = float>
-Tensor<T, 1> arange(T start, T end, T step) {
+Tensor<T, 1> arange(T start, T end, T step, const Order order = Order::C) {
     int n = static_cast<int>(std::ceil(double(end - start) / step));
     assert(n > 0);
-    auto tensor = zeros<T>(n);
+    auto tensor = zeros<T>(n, order);
     thrust::transform(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(n), tensor.begin(),
                       [start, step] __device__(int i) -> T { return start + i * step; });
     return tensor;
@@ -48,13 +50,14 @@ Tensor<T, 1> arange(T start, T end, T step) {
  * @param start: The starting value of the sequence.
  * @param end: The end value of the sequence.
  * @param step: The step size of the sequence.
+ * @param order: The order of the tensor.
  * @return Tensor<T*, 1>: The new tensor object.
  */
 template <typename T>
-Tensor<T*, 1> arange(T* start, T* end, int step) {
+Tensor<T*, 1> arange(T* start, T* end, int step, const Order order = Order::C) {
     int n = static_cast<int>(std::ceil(double(end - start) / step));
     assert(n > 0);
-    auto tensor = zeros<T*>(n);
+    auto tensor = zeros<T*>(n, order);
     thrust::transform(thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(n), tensor.begin(),
                       [start, step] __device__(int i) -> T* { return start + i * step; });
     return tensor;

--- a/lib/generator/diag.hpp
+++ b/lib/generator/diag.hpp
@@ -36,7 +36,7 @@ __global__ void gen_diag_kernel(CuTensor<T, 1> tensor, int k, CuTensor<T, 2> res
 template <typename T>
 Tensor<T, 2> diag(Tensor<T, 1> tensor, int k = 0) {
     auto m = tensor.size() + std::abs(k);
-    auto result = zeros<T>(m, m);
+    auto result = zeros<T>(m, m, tensor.order());
     auto nblocks = (m + NUM_THREADS_X - 1) / NUM_THREADS_X;
     gen_diag_kernel<T><<<nblocks, NUM_THREADS_X>>>(tensor, k, result);
     return result;
@@ -73,7 +73,7 @@ template <typename T>
 Tensor<T, 1> diag(Tensor<T, 2> tensor, int k = 0) {
     auto [m, n] = tensor.shape();
     size_t ndiag = (k >= 0) ? std::min(m, n - k) : std::min(m + k, n);
-    auto result = zeros<T>(ndiag);
+    auto result = zeros<T>(ndiag, tensor.order());
     auto nblocks = (ndiag + NUM_THREADS_X - 1) / NUM_THREADS_X;
     get_diag_kernel<T><<<nblocks, NUM_THREADS_X>>>(tensor, k, result);
     return result;

--- a/lib/generator/eye.hpp
+++ b/lib/generator/eye.hpp
@@ -27,11 +27,12 @@ __global__ void eye_kernel(CuTensor<T, 2> tensor, size_t ndiag) {
  * @tparam T: Data type of the tensor.
  * @param m: The number of rows.
  * @param n: The number of columns.
+ * @param order: The order of the tensor.
  * @return Tensor<T, 2>: The new tensor object.
  */
 template <typename T = float>
-Tensor<T, 2> eye(size_t m, size_t n) {
-    auto tensor = zeros<T>(m, n);
+Tensor<T, 2> eye(size_t m, size_t n, const Order order = Order::C) {
+    auto tensor = zeros<T>(m, n, order);
     size_t ndiag = std::min(m, n);
     auto nblocks = (ndiag + NUM_THREADS_X - 1) / NUM_THREADS_X;
     eye_kernel<T><<<nblocks, NUM_THREADS_X>>>(tensor, ndiag);
@@ -43,11 +44,12 @@ Tensor<T, 2> eye(size_t m, size_t n) {
  *
  * @tparam T: Data type of the tensor.
  * @param m: The number of rows and columns.
+ * @param order: The order of the tensor.
  * @return Tensor<T, 2>: The new tensor object.
  */
 template <typename T = float>
-Tensor<T, 2> eye(size_t m) {
-    return eye<T>(m, m);
+Tensor<T, 2> eye(size_t m, const Order order = Order::C) {
+    return eye<T>(m, m, order);
 }
 
 }  // namespace vt

--- a/lib/generator/ones.hpp
+++ b/lib/generator/ones.hpp
@@ -7,15 +7,17 @@ namespace vt {
 /**
  * @brief Returns a new array of given shape, filled with ones.
  *
- * @param args: Shape of the tensor.
  * @tparam T: Data type of the tensor.
+ * @tparam N: Number of dimensions of the tensor.
+ * @param shape: Shape of the tensor.
+ * @param order: The order of the tensor.
  * @return Tensor: The new tensor object.
  */
 template <typename T = float, size_t N>
-Tensor<T, N> ones(Shape<N> shape) {
+Tensor<T, N> ones(Shape<N> shape, const Order order = Order::C) {
     using vector_type = typename Tensor<T, N>::vector_type;
     vector_type data(get_size(shape), T{1});
-    return Tensor<T, N>(std::make_shared<vector_type>(data), shape);
+    return Tensor<T, N>(std::make_shared<vector_type>(data), shape, order);
 }
 
 /**
@@ -23,11 +25,12 @@ Tensor<T, N> ones(Shape<N> shape) {
  *
  * @tparam T: Data type of the tensor.
  * @param m: Size of the tensor.
+ * @param order: The order of the tensor.
  * @return Tensor<T, 1>: The new tensor object.
  */
 template <typename T = float>
-Tensor<T, 1> ones(size_t m) {
-    return ones(Shape<1>{m});
+Tensor<T, 1> ones(size_t m, const Order order = Order::C) {
+    return ones(Shape<1>{m}, order);
 }
 
 /**
@@ -36,11 +39,12 @@ Tensor<T, 1> ones(size_t m) {
  * @tparam T: Data type of the tensor.
  * @param m: Number of rows of the tensor.
  * @param n: Number of columns of the tensor.
+ * @param order: The order of the tensor.
  * @return Tensor<T, 2>: The new tensor object.
  */
 template <typename T = float>
-Tensor<T, 2> ones(size_t m, size_t n) {
-    return ones<T, 2>(Shape<2>{m, n});
+Tensor<T, 2> ones(size_t m, size_t n, const Order order = Order::C) {
+    return ones<T, 2>(Shape<2>{m, n}, order);
 }
 
 }  // namespace vt

--- a/lib/generator/tests/test_arange.cc
+++ b/lib/generator/tests/test_arange.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(ArangeGenerator, BasicAssertions) {
+TEST(ArangeGeneratorC, BasicAssertions) {
     auto tensor = vt::arange(12);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 
@@ -28,6 +28,37 @@ TEST(ArangeGenerator, BasicAssertions) {
     for (auto i = 0; i < 5; ++i) EXPECT_NEAR(vec[i], 9.2 - i * 2.0, 1e-6);
 
     auto tensor6 = vt::arange(0.9f, 0.1f, -0.3f);
+    vec = vt::asvector(tensor6);
+    EXPECT_EQ(vec.size(), 3);
+    for (auto i = 0; i < 3; ++i) EXPECT_NEAR(vec[i], 0.9 - i * 0.3, 1e-6);
+}
+
+TEST(ArangeGeneratorF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+
+    auto tensor1 = vt::arange<int>(1, 12, 2, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<int>{1, 3, 5, 7, 9, 11}));
+
+    float arr[3] = {0.0f, 1.0f, 2.0f};
+    float* ptr = &arr[0];
+    auto tensor2 = vt::arange(ptr, ptr + 3, 2, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float*>{ptr, ptr + 2}));
+
+    auto tensor3 = vt::arange(1.2f, 11.2f, 2.0f, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{1.2, 3.2, 5.2, 7.2, 9.2}));
+
+    auto tensor4 = vt::arange(0.0f, 1.0f, 0.3f, vt::Order::F);
+    auto vec = vt::asvector(tensor4);
+    EXPECT_EQ(vec.size(), 4);
+    for (auto i = 0; i < 4; ++i) EXPECT_NEAR(vec[i], i * 0.3, 1e-6);
+
+    auto tensor5 = vt::arange(9.2f, 1.0f, -2.0f, vt::Order::F);
+    vec = vt::asvector(tensor5);
+    EXPECT_EQ(vec.size(), 5);
+    for (auto i = 0; i < 5; ++i) EXPECT_NEAR(vec[i], 9.2 - i * 2.0, 1e-6);
+
+    auto tensor6 = vt::arange(0.9f, 0.1f, -0.3f, vt::Order::F);
     vec = vt::asvector(tensor6);
     EXPECT_EQ(vec.size(), 3);
     for (auto i = 0; i < 3; ++i) EXPECT_NEAR(vec[i], 0.9 - i * 0.3, 1e-6);

--- a/lib/generator/tests/test_diag.cc
+++ b/lib/generator/tests/test_diag.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Test1DDiag, BasicAssertions) {
+TEST(Test1DDiagC, BasicAssertions) {
     auto x = vt::arange(6)({0, 6, 2});
     auto re = vt::diag(x);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 0, 0, 2, 0, 0, 0, 4}));
@@ -14,7 +14,19 @@ TEST(Test1DDiag, BasicAssertions) {
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0 ,4 ,0}));
 }
 
-TEST(Test2DDiag, BasicAssertions) {
+TEST(Test1DDiagF, BasicAssertions) {
+    auto x = vt::arange(6, vt::Order::F)({0, 6, 2});
+    auto re = vt::diag(x);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 0, 0, 2, 0, 0, 0, 4}));
+
+    re = vt::diag(x, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0}));
+
+    re = vt::diag(x, -1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 4, 0, 0, 0, 0}));
+}
+
+TEST(Test2DDiagC, BasicAssertions) {
     auto x = vt::arange(24)({0, 24, 2}).reshape(3, 4);
     auto re = vt::diag(x);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 10 ,20}));
@@ -24,4 +36,16 @@ TEST(Test2DDiag, BasicAssertions) {
 
     re = vt::diag(x, -1);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{8, 18}));
+}
+
+TEST(Test2DDiagF, BasicAssertions) {
+    auto x = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(3, 4);
+    auto re = vt::diag(x);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 8, 16}));
+
+    re = vt::diag(x, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{6, 14 ,22}));
+
+    re = vt::diag(x, -1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{2, 10}));
 }

--- a/lib/generator/tests/test_eye.cc
+++ b/lib/generator/tests/test_eye.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(EyeGenerator, BasicAssertions) {
+TEST(EyeGeneratorC, BasicAssertions) {
     auto tensor = vt::eye(3, 2);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 0, 0, 1, 0, 0}));
 
@@ -10,5 +10,16 @@ TEST(EyeGenerator, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 0, 0, 0, 1, 0}));
 
     tensor = vt::eye(2);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 0, 0, 1}));
+}
+
+TEST(EyeGeneratorF, BasicAssertions) {
+    auto tensor = vt::eye(3, 2, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 0, 0, 0, 1, 0}));
+
+    tensor = vt::eye(2, 3, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 0, 0, 1, 0, 0}));
+
+    tensor = vt::eye(2, vt::Order::F);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 0, 0, 1}));
 }

--- a/lib/generator/tests/test_ones.cc
+++ b/lib/generator/tests/test_ones.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(OnesGenerator, BasicAssertions) {
+TEST(OnesGeneratorC, BasicAssertions) {
     auto tensor1 = vt::ones(vt::Shape<1>{12});
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
 
@@ -10,5 +10,16 @@ TEST(OnesGenerator, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
 
     auto tensor3 = vt::ones(3, 4);
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+}
+
+TEST(OnesGeneratorF, BasicAssertions) {
+    auto tensor1 = vt::ones(vt::Shape<1>{12}, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+
+    auto tensor2 = vt::ones(12, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
+
+    auto tensor3 = vt::ones(3, 4, vt::Order::F);
     EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}));
 }

--- a/lib/generator/tests/test_tri.cc
+++ b/lib/generator/tests/test_tri.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(TestTri, BasicAssertions) {
+TEST(TestTriC, BasicAssertions) {
     auto tensor = vt::tri(2, 3);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 0, 0, 1, 1, 0}));
 
@@ -11,10 +11,20 @@ TEST(TestTri, BasicAssertions) {
 
     tensor = vt::tri(2, 3, 1);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 1, 0, 1, 1, 1}));
-
 }
 
-TEST(TestTril, BasicAssertions) {
+TEST(TestTriF, BasicAssertions) {
+    auto tensor = vt::tri(2, 3, 0, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 1, 0, 1, 0, 0}));
+
+    tensor = vt::tri(2, 3, -1, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 0, 0, 0, 0}));
+
+    tensor = vt::tri(2, 3, 1, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{1, 1, 1, 1, 0, 1}));
+}
+
+TEST(TestTrilC, BasicAssertions) {
     auto tensor = vt::arange(24)({0, 24, 2}).reshape(2, 2, 3);
     auto re = vt::tril(tensor);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 0, 6, 8, 0, 12, 0, 0, 18, 20, 0}));
@@ -36,7 +46,30 @@ TEST(TestTril, BasicAssertions) {
     EXPECT_EQ(vt::asvector(re1), (std::vector<float>{0, 0, 0, 0, 8, 0, 0, 0, 16, 18, 0, 0}));
 }
 
-TEST(TestTriu, BasicAssertions) {
+TEST(TestTrilF, BasicAssertions) {
+    auto tensor = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(2, 2, 3);
+    auto re = vt::tril(tensor);
+
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 2, 4, 6, 0, 0, 12, 14, 0, 0, 0, 0}));
+
+    re = vt::tril(tensor, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 14, 0, 0, 20, 22}));
+
+    re = vt::tril(tensor, -1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 4, 6, 0, 0, 0, 0, 0, 0, 0, 0}));
+
+    auto tensor1 = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(3, 4);
+    auto re1 = vt::tril(tensor1);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<float>{0, 2, 4, 0, 8, 10, 0, 0, 16, 0, 0, 0}));
+
+    re1 = vt::tril(tensor1, 1);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<float>{0, 2, 4, 6, 8, 10, 0, 14, 16, 0, 0, 22}));
+
+    re1 = vt::tril(tensor1, -1);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<float>{0, 2, 4, 0, 0, 10, 0, 0, 0, 0, 0, 0}));
+}
+
+TEST(TestTriuC, BasicAssertions) {
     auto tensor = vt::arange(24)({0, 24, 2}).reshape(2, 2, 3);
     auto re = vt::triu(tensor);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 2, 4, 0, 8, 10, 12, 14, 16, 0, 20, 22}));
@@ -56,4 +89,26 @@ TEST(TestTriu, BasicAssertions) {
 
     re1 = vt::triu(tensor1, -1);
     EXPECT_EQ(vt::asvector(re1), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 14, 0, 18, 20, 22}));
+}
+
+TEST(TestTriuF, BasicAssertions) {
+    auto tensor = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(2, 2, 3);
+    auto re = vt::triu(tensor);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 2, 0, 0, 8, 10, 12, 14, 16, 18, 20, 22}));
+
+    re = vt::triu(tensor, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 0, 0, 8, 10, 0, 0, 16, 18, 20, 22}));
+
+    re = vt::triu(tensor, -1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22}));
+
+    auto tensor1 = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(3, 4);
+    auto re1 = vt::triu(tensor1);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<float>{0, 0, 0, 6, 8, 0, 12, 14, 16, 18, 20, 22}));
+
+    re1 = vt::triu(tensor1, 1);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<float>{0, 0, 0, 6, 0, 0, 12, 14, 0, 18, 20, 22}));
+
+    re1 = vt::triu(tensor1, -1);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<float>{0, 2, 0, 6, 8, 10, 12, 14, 16, 18, 20, 22}));
 }

--- a/lib/generator/tests/test_zeros.cc
+++ b/lib/generator/tests/test_zeros.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(ZerosGenerator, BasicAssertions) {
+TEST(ZerosGeneratorC, BasicAssertions) {
     auto tensor1 = vt::zeros(vt::Shape<1>{12});
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
@@ -10,5 +10,16 @@ TEST(ZerosGenerator, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 
     auto tensor3 = vt::zeros(3, 4);
+    EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+}
+
+TEST(ZerosGeneratorF, BasicAssertions) {
+    auto tensor1 = vt::zeros(vt::Shape<1>{12}, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+
+    auto tensor2 = vt::zeros(12, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
+
+    auto tensor3 = vt::zeros(3, 4, vt::Order::F);
     EXPECT_EQ(vt::asvector(tensor3), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}));
 }

--- a/lib/generator/tri.hpp
+++ b/lib/generator/tri.hpp
@@ -33,12 +33,13 @@ __global__ void tri_kernel(CuTensor<T, 2> tensor, int k) {
  * @param m: Number of rows in the tensor.
  * @param n: Number of columns in the tensor.
  * @param k: An offset for the sub-diagonal at and below which the tensor is filled.
+ * @param order: The order of the tensor.
  * @return Tensor: The result tensor.
  */
 template <typename T = float>
-Tensor<T, 2> tri(size_t m, size_t n = 0, int k = 0) {
+Tensor<T, 2> tri(size_t m, size_t n = 0, int k = 0, const Order order = Order::C) {
     if (n == 0) n = m;
-    auto tensor = zeros<T>(m, n);
+    auto tensor = zeros<T>(m, n, order);
     dim3 tpb(16, 16);
     dim3 blk((m + tpb.x - 1) / tpb.x, (n + tpb.y - 1) / tpb.y);
     tri_kernel<T><<<blk, tpb>>>(tensor, k);
@@ -95,7 +96,7 @@ template <typename T, size_t N>
 Tensor<T, N> tril(const Tensor<T, N>& tensor, int k = 0) {
     assert_at_least_2d_tensor<N>();
     auto shape = tensor.shape();
-    auto mask = tri<bool>(shape[N - 2], shape[N - 1], k);
+    auto mask = tri<bool>(shape[N - 2], shape[N - 1], k, tensor.order());
     return where(mask, tensor, static_cast<T>(0));
 }
 
@@ -149,7 +150,7 @@ template <typename T, size_t N>
 Tensor<T, N> triu(const Tensor<T, N>& tensor, int k = 0) {
     assert_at_least_2d_tensor<N>();
     auto shape = tensor.shape();
-    auto mask = tri<bool>(shape[N - 2], shape[N - 1], k - 1);
+    auto mask = tri<bool>(shape[N - 2], shape[N - 1], k - 1, tensor.order());
     return where(mask, static_cast<T>(0), tensor);
 }
 

--- a/lib/generator/zeros.hpp
+++ b/lib/generator/zeros.hpp
@@ -7,14 +7,15 @@ namespace vt {
 /**
  * @brief Returns a new array of given shape, filled with zeros.
  *
- * @param shape: Shape of the tensor.
  * @tparam T: Data type of the tensor.
  * @tparam N: Number of dimensions of the tensor.
+ * @param shape: Shape of the tensor.
+ * @param order: The order of the tensor.
  * @return Tensor: The new tensor object.
  */
 template <typename T = float, size_t N>
-Tensor<T, N> zeros(Shape<N> shape) {
-    return Tensor<T, N>(shape);
+Tensor<T, N> zeros(Shape<N> shape, const Order order = Order::C) {
+    return Tensor<T, N>(shape, order);
 }
 
 /**
@@ -22,11 +23,12 @@ Tensor<T, N> zeros(Shape<N> shape) {
  *
  * @tparam T: Data type of the tensor.
  * @param m: Size of the tensor.
+ * @param order: The order of the tensor.
  * @return Tensor<T, 1>: The new tensor object.
  */
 template <typename T = float>
-Tensor<T, 1> zeros(size_t m) {
-    return zeros<T, 1>(Shape<1>{m});
+Tensor<T, 1> zeros(size_t m, const Order order = Order::C) {
+    return zeros<T, 1>(Shape<1>{m}, order);
 }
 
 /**
@@ -35,11 +37,12 @@ Tensor<T, 1> zeros(size_t m) {
  * @tparam T: Data type of the tensor.
  * @param m: Number of rows of the tensor.
  * @param n: Number of columns of the tensor.
+ * @param order: The order of the tensor.
  * @return Tensor<T, 2>: The new tensor object.
  */
 template <typename T = float>
-Tensor<T, 2> zeros(size_t m, size_t n) {
-    return zeros<T, 2>(Shape<2>{m, n});
+Tensor<T, 2> zeros(size_t m, size_t n, const Order order = Order::C) {
+    return zeros<T, 2>(Shape<2>{m, n}, order);
 }
 
 }  // namespace vt

--- a/lib/linalg/cholesky.hpp
+++ b/lib/linalg/cholesky.hpp
@@ -20,6 +20,7 @@ namespace linalg {
  */
 template <typename T>
 Tensor<T, 2> cholesky(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+    assert(tensor.order() == vt::Order::C);
     auto [n, m] = tensor.shape();
     assert(n == m);
     auto x = copy(tensor);
@@ -52,6 +53,7 @@ Tensor<T, 2> cholesky(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cu
  */
 template <typename T, size_t N>
 Tensor<T, N> cholesky(Tensor<T, N>& tensor, cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+    assert(tensor.order() == vt::Order::C);
     assert_at_least_3d_tensor<N>();
     auto shape = tensor.shape();
     assert(shape[N - 1] == shape[N - 2]);

--- a/lib/linalg/inv.hpp
+++ b/lib/linalg/inv.hpp
@@ -23,6 +23,7 @@ namespace linalg {
  */
 template <typename T>
 Tensor<T, 2> inv(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+    assert(tensor.order() == vt::Order::C);
     auto shape = tensor.shape();
     assert(shape[0] == shape[1]);
 
@@ -65,6 +66,7 @@ Tensor<T, 2> inv(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cusolve
  */
 template <typename T, size_t N>
 Tensor<T, N> inv(Tensor<T, N>& tensor, cublasHandle_t handle = cuda::cublas.get_handle()) {
+    assert(tensor.order() == vt::Order::C);
     assert_at_least_3d_tensor<N>();
     auto shape = tensor.shape();
     assert(shape[N - 1] == shape[N - 2]);

--- a/lib/linalg/matmul.hpp
+++ b/lib/linalg/matmul.hpp
@@ -19,6 +19,8 @@ namespace vt {
  */
 template <typename T>
 Tensor<T, 1> matmul(Tensor<T, 1>& tensor1, Tensor<T, 1>& tensor2, cublasHandle_t handle = cuda::cublas.get_handle()) {
+    assert(tensor1.order() == vt::Order::C);
+    assert(tensor2.order() == vt::Order::C);
     assert(tensor1.size() == tensor2.size());
     auto t1 = ascontiguoustensor(tensor1);
     auto t2 = ascontiguoustensor(tensor2);
@@ -39,6 +41,8 @@ Tensor<T, 1> matmul(Tensor<T, 1>& tensor1, Tensor<T, 1>& tensor2, cublasHandle_t
  */
 template <typename T>
 Tensor<T, 2> matmul(Tensor<T, 2>& tensor1, Tensor<T, 2>& tensor2, cublasHandle_t handle = cuda::cublas.get_handle()) {
+    assert(tensor1.order() == vt::Order::C);
+    assert(tensor2.order() == vt::Order::C);
     auto shape1 = tensor1.shape();
     auto shape2 = tensor2.shape();
     assert(shape1[1] == shape2[0]);
@@ -72,6 +76,8 @@ Tensor<T, 2> matmul(Tensor<T, 2>& tensor1, Tensor<T, 2>& tensor2, cublasHandle_t
  */
 template <typename T, size_t N>
 Tensor<T, N> matmul(Tensor<T, N>& tensor1, Tensor<T, N>& tensor2, cublasHandle_t handle = cuda::cublas.get_handle()) {
+    assert(tensor1.order() == vt::Order::C);
+    assert(tensor2.order() == vt::Order::C);
     assert_at_least_3d_tensor<N>();
     auto shape1 = tensor1.shape();
     auto shape2 = tensor2.shape();

--- a/lib/linalg/pinv.hpp
+++ b/lib/linalg/pinv.hpp
@@ -20,6 +20,7 @@ namespace linalg {
  */
 template <typename T, size_t N>
 Tensor<T, N> pinv(Tensor<T, N>& tensor, T rcond = 1e-15) {
+    assert(tensor.order() == vt::Order::C);
     auto [u, s, vt] = svd(tensor, false);
     auto cutoff = rcond * max(s, -1);
 

--- a/lib/linalg/product.hpp
+++ b/lib/linalg/product.hpp
@@ -17,6 +17,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 T dot(Tensor<T, N> tensor1, Tensor<T, N> tensor2) {
+    assert_same_order_between_two_tensors(tensor1.order(), tensor2.order());
     assert(tensor1.shape() == tensor2.shape());
     auto re = thrust::inner_product(tensor1.begin(), tensor1.end(), tensor2.begin(), T{0.0});
     return re;

--- a/lib/linalg/svd.hpp
+++ b/lib/linalg/svd.hpp
@@ -27,6 +27,7 @@ namespace linalg {
 template <typename T>
 std::tuple<Tensor<T, 2>, Tensor<T, 1>, Tensor<T, 2>> svd(Tensor<T, 2>& tensor, bool full_matrices = true, bool compute_uv = true,
                                                          cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+    assert(tensor.order() == vt::Order::C);
     auto [n, m] = tensor.shape();
     Tensor<T, 2> x;
     bool trans_flag;
@@ -109,6 +110,7 @@ std::tuple<Tensor<T, 2>, Tensor<T, 1>, Tensor<T, 2>> svd(Tensor<T, 2>& tensor, b
 template <typename T, size_t N>
 std::tuple<Tensor<T, N>, Tensor<T, N - 1>, Tensor<T, N>> svd(Tensor<T, N>& tensor, bool full_matrices = true, bool compute_uv = true,
                                                              cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+    assert(tensor.order() == vt::Order::C);
     assert_at_least_3d_tensor<N>();
     auto shape = tensor.shape();
     Shape<N - 2> batch_shape;

--- a/lib/linalg/tests/test_product.cc
+++ b/lib/linalg/tests/test_product.cc
@@ -2,9 +2,19 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Dot, BasicAssertions) {
+TEST(DotC, BasicAssertions) {
     auto t1 = vt::arange(12)({1, 12, 2});
     auto t2 = vt::arange(12)({0, 12, 2});
+    auto re = vt::dot(t1, t2);
+    EXPECT_EQ(re, 250);
+
+    re = vt::dot(t1[1], t2[1]);
+    EXPECT_EQ(re, 6);
+}
+
+TEST(DotF, BasicAssertions) {
+    auto t1 = vt::arange(12, vt::Order::F)({1, 12, 2});
+    auto t2 = vt::arange(12, vt::Order::F)({0, 12, 2});
     auto re = vt::dot(t1, t2);
     EXPECT_EQ(re, 250);
 

--- a/lib/logical/all.hpp
+++ b/lib/logical/all.hpp
@@ -40,7 +40,7 @@ template <typename T, size_t N>
 __global__ void all_along_axis_kernel(CuTensor<T, N> tensor, CuTensor<bool, N - 1> result) {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= result.size) return;
-    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start);
+    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start, tensor.order);
     for (auto i = 0; i < tensor.shape[N - 1]; ++i) {
         if (!tensor.data[start + i * tensor.strides[N - 1]]) {
             result[idx] = false;

--- a/lib/logical/any.hpp
+++ b/lib/logical/any.hpp
@@ -39,7 +39,7 @@ template <typename T, size_t N>
 __global__ void any_along_axis_kernel(CuTensor<T, N> tensor, CuTensor<bool, N - 1> result) {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= result.size) return;
-    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start);
+    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start, tensor.order);
     for (auto i = 0; i < tensor.shape[N - 1]; ++i) {
         if (tensor.data[start + i * tensor.strides[N - 1]]) {
             result[idx] = true;

--- a/lib/logical/tests/test_all.cc
+++ b/lib/logical/tests/test_all.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(All, BasicAssertions) {
+TEST(allC, BasicAssertions) {
     auto tensor = vt::arange(12);
     EXPECT_EQ(vt::all(tensor), false);
 
@@ -16,6 +16,25 @@ TEST(All, BasicAssertions) {
     EXPECT_EQ(vt::all(tensor), true);
 
     auto tensor2 = vt::ones(12)({0, 12, 2}).reshape(2, 3);
+    tensor2({0}, {0, 3}) = 0.0f;
+    EXPECT_EQ(vt::asvector(vt::all(tensor2, 0)), (std::vector<bool>{0, 0, 0}));
+    EXPECT_EQ(vt::asvector(vt::all(tensor2, 1)), (std::vector<bool>{0, 1}));
+}
+
+TEST(allF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F);
+    EXPECT_EQ(vt::all(tensor), false);
+
+    tensor = vt::ones(12, vt::Order::F);
+    EXPECT_EQ(vt::all(tensor), true);
+
+    tensor = vt::arange(12, vt::Order::F)({0, 12, 2});
+    EXPECT_EQ(vt::all(tensor), false);
+
+    tensor = vt::arange(12, vt::Order::F)({1, 12, 2});
+    EXPECT_EQ(vt::all(tensor), true);
+
+    auto tensor2 = vt::ones(12, vt::Order::F)({0, 12, 2}).reshape(2, 3);
     tensor2({0}, {0, 3}) = 0.0f;
     EXPECT_EQ(vt::asvector(vt::all(tensor2, 0)), (std::vector<bool>{0, 0, 0}));
     EXPECT_EQ(vt::asvector(vt::all(tensor2, 1)), (std::vector<bool>{0, 1}));

--- a/lib/logical/tests/test_any.cc
+++ b/lib/logical/tests/test_any.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Any, BasicAssertions) {
+TEST(anyC, BasicAssertions) {
     auto tensor = vt::arange(12);
     EXPECT_EQ(vt::any(tensor), true);
 
@@ -16,6 +16,25 @@ TEST(Any, BasicAssertions) {
     EXPECT_EQ(vt::any(tensor), false);
 
     auto tensor2 = vt::ones(12)({0, 12, 2}).reshape(2, 3);
+    tensor2({0}, {0, 3}) = 0.0f;
+    EXPECT_EQ(vt::asvector(vt::any(tensor2, 0)), (std::vector<bool>{1, 1, 1}));
+    EXPECT_EQ(vt::asvector(vt::any(tensor2, 1)), (std::vector<bool>{0, 1}));
+}
+
+TEST(anyF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F);
+    EXPECT_EQ(vt::any(tensor), true);
+
+    tensor = vt::zeros(12, vt::Order::F);
+    EXPECT_EQ(vt::any(tensor), false);
+
+    tensor = vt::arange(12, vt::Order::F)({0, 12, 2});
+    EXPECT_EQ(vt::any(tensor), true);
+
+    tensor = vt::arange(12, vt::Order::F)({0});
+    EXPECT_EQ(vt::any(tensor), false);
+
+    auto tensor2 = vt::ones(12, vt::Order::F)({0, 12, 2}).reshape(2, 3);
     tensor2({0}, {0, 3}) = 0.0f;
     EXPECT_EQ(vt::asvector(vt::any(tensor2, 0)), (std::vector<bool>{1, 1, 1}));
     EXPECT_EQ(vt::asvector(vt::any(tensor2, 1)), (std::vector<bool>{0, 1}));

--- a/lib/logical/tests/test_where.cc
+++ b/lib/logical/tests/test_where.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(where, BasicAssertions) {
+TEST(whereC, BasicAssertions) {
     auto condition = vt::arange(24)({0, 24, 2}).reshape(2, 2, 3) > 12.0f;
     auto x = vt::arange(24)({0, 24, 2}).reshape(2, 2, 3);
     auto y = vt::ones(12).reshape(2, 2, 3);
@@ -14,5 +14,18 @@ TEST(where, BasicAssertions) {
 
     r = vt::where(condition, x, 0.0f);
     EXPECT_EQ(vt::asvector(r), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 14, 16, 18, 20, 22}));
+}
 
+TEST(whereF, BasicAssertions) {
+    auto condition = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(2, 2, 3) > 12.0f;
+    auto x = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(2, 2, 3);
+    auto y = vt::ones(12, vt::Order::F).reshape(2, 2, 3);
+    auto r = vt::where(condition, x, y);
+    EXPECT_EQ(vt::asvector(r), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 14, 16, 18, 20, 22}));
+
+    r = vt::where(condition, 0.0f, y);
+    EXPECT_EQ(vt::asvector(r), (std::vector<float>{1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0}));
+
+    r = vt::where(condition, x, 0.0f);
+    EXPECT_EQ(vt::asvector(r), (std::vector<float>{0, 0, 0, 0, 0, 0, 0, 14, 16, 18, 20, 22}));
 }

--- a/lib/math/exp.hpp
+++ b/lib/math/exp.hpp
@@ -15,7 +15,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, N> exp(const Tensor<T, N>& tensor) {
-    auto result = vt::zeros<T>(tensor.shape());
+    auto result = vt::zeros<T>(tensor.shape(), tensor.order());
     thrust::transform(tensor.begin(), tensor.end(), result.begin(), [] __device__(const T& x) {
         if constexpr (std::is_same<T, float>::value)
             return expf(x);

--- a/lib/math/max.hpp
+++ b/lib/math/max.hpp
@@ -19,7 +19,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, 0> max(const Tensor<T, N>& tensor) {
-    auto result = Tensor<T, 0>(Shape<0>{});
+    auto result = Tensor<T, 0>(Shape<0>{}, tensor.order());
     (*result.data())[0] = *thrust::max_element(tensor.begin(), tensor.end());
     return result;
 }
@@ -37,7 +37,7 @@ template <typename T, size_t N>
 __global__ void max_along_axis_kernel(CuTensor<T, N> tensor, CuTensor<T, N - 1> result) {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= result.size) return;
-    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start);
+    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start, tensor.order);
     auto value = tensor.data[start];
     for (auto i = 0; i < tensor.shape[N - 1]; ++i) value = std::max(value, tensor.data[start + i * tensor.strides[N - 1]]);
     result[idx] = value;

--- a/lib/math/maximum.hpp
+++ b/lib/math/maximum.hpp
@@ -19,7 +19,8 @@ namespace vt {
 template <typename T, size_t N>
 Tensor<T, N> maximum(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
     assert(lhs.shape() == rhs.shape());
-    auto result = zeros<T>(lhs.shape());
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
+    auto result = zeros<T>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), rhs.begin(), result.begin(), thrust::maximum<T>());
     return result;
 }
@@ -35,7 +36,7 @@ Tensor<T, N> maximum(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> maximum(const Tensor<T, N>& lhs, const T value) {
-    auto result = zeros<T>(lhs.shape());
+    auto result = zeros<T>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), thrust::maximum<T>());
     return result;
 }

--- a/lib/math/mean.hpp
+++ b/lib/math/mean.hpp
@@ -20,7 +20,7 @@ namespace vt {
  */
 template <typename T = float, size_t N>
 Tensor<T, 0> mean(const Tensor<bool, N>& tensor) {
-    auto result = Tensor<T, 0>(Shape<0>{});
+    auto result = Tensor<T, 0>(Shape<0>{}, tensor.order());
     T s = thrust::reduce(tensor.begin(), tensor.end(), 0, thrust::plus<int>());
     (*result.data())[0] = s / tensor.size();
     return result;
@@ -36,7 +36,7 @@ Tensor<T, 0> mean(const Tensor<bool, N>& tensor) {
  */
 template <typename T, size_t N>
 Tensor<T, 0> mean(const Tensor<T, N>& tensor) {
-    auto result = Tensor<T, 0>(Shape<0>{});
+    auto result = Tensor<T, 0>(Shape<0>{}, tensor.order());
     T s = thrust::reduce(tensor.begin(), tensor.end(), (T)0, thrust::plus<T>());
     (*result.data())[0] = s / tensor.size();
     return result;
@@ -56,7 +56,7 @@ template <typename T, typename U, size_t N>
 __global__ void mean_along_axis_kernel(CuTensor<U, N> tensor, CuTensor<T, N - 1> result) {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= result.size) return;
-    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start);
+    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start, tensor.order);
     auto sum = T{0};
     for (auto i = 0; i < tensor.shape[N - 1]; ++i) sum += tensor.data[start + i * tensor.strides[N - 1]];
     result[idx] = sum / tensor.shape[N - 1];

--- a/lib/math/min.hpp
+++ b/lib/math/min.hpp
@@ -19,7 +19,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, 0> min(const Tensor<T, N>& tensor) {
-    auto result = Tensor<T, 0>(Shape<0>{});
+    auto result = Tensor<T, 0>(Shape<0>{}, tensor.order());
     (*result.data())[0] = *thrust::min_element(tensor.begin(), tensor.end());
     return result;
 }
@@ -37,7 +37,7 @@ template <typename T, size_t N>
 __global__ void min_along_axis_kernel(CuTensor<T, N> tensor, CuTensor<T, N - 1> result) {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= result.size) return;
-    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start);
+    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start, tensor.order);
     auto value = tensor.data[start];
     for (auto i = 0; i < tensor.shape[N - 1]; ++i) value = std::min(value, tensor.data[start + i * tensor.strides[N - 1]]);
     result[idx] = value;

--- a/lib/math/minimum.hpp
+++ b/lib/math/minimum.hpp
@@ -19,7 +19,8 @@ namespace vt {
 template <typename T, size_t N>
 Tensor<T, N> minimum(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
     assert(lhs.shape() == rhs.shape());
-    auto result = zeros<T>(lhs.shape());
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
+    auto result = zeros<T>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), rhs.begin(), result.begin(), thrust::minimum<T>());
     return result;
 }
@@ -35,7 +36,7 @@ Tensor<T, N> minimum(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> minimum(const Tensor<T, N>& lhs, const T value) {
-    auto result = zeros<T>(lhs.shape());
+    auto result = zeros<T>(lhs.shape(), lhs.order());
     auto v = static_cast<T>(value);
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(v), result.begin(), thrust::minimum<T>());
     return result;

--- a/lib/math/power.hpp
+++ b/lib/math/power.hpp
@@ -17,8 +17,9 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, N> power(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
+    assert_same_order_between_two_tensors(lhs.order(), rhs.order());
     auto [_lhs, _rhs] = broadcast(lhs, rhs);
-    auto result = vt::zeros<T>(_lhs.shape());
+    auto result = vt::zeros<T>(_lhs.shape(), lhs.order());
     thrust::transform(_lhs.begin(), _lhs.end(), _rhs.begin(), result.begin(), [] __device__(const T& x, const T& y) {
         if constexpr (std::is_same<T, float>::value)
             return powf(x, y);
@@ -39,7 +40,7 @@ Tensor<T, N> power(const Tensor<T, N>& lhs, const Tensor<T, N>& rhs) {
  */
 template <typename T, size_t N>
 Tensor<T, N> power(const Tensor<T, N>& lhs, const T value) {
-    auto result = vt::zeros<T>(lhs.shape());
+    auto result = vt::zeros<T>(lhs.shape(), lhs.order());
     thrust::transform(lhs.begin(), lhs.end(), thrust::make_constant_iterator(value), result.begin(), [] __device__(const T& x, const T& y) {
         if constexpr (std::is_same<T, float>::value)
             return powf(x, y);
@@ -60,7 +61,7 @@ Tensor<T, N> power(const Tensor<T, N>& lhs, const T value) {
  */
 template <typename T, size_t N>
 Tensor<T, N> power(const T value, const Tensor<T, N>& rhs) {
-    auto result = vt::zeros<T>(rhs.shape());
+    auto result = vt::zeros<T>(rhs.shape(), rhs.order());
     thrust::transform(rhs.begin(), rhs.end(), thrust::make_constant_iterator(value), result.begin(), [] __device__(const T& x, const T& y) {
         if constexpr (std::is_same<T, float>::value)
             return powf(y, x);

--- a/lib/math/reduce.hpp
+++ b/lib/math/reduce.hpp
@@ -27,7 +27,7 @@ Tensor<T, N - 1> reduce_along_axis(const Tensor<U, N>& tensor, int axis, KernelF
     Shape<N - 1> new_shape;
     auto shape = _tensor.shape();
     std::copy(shape.begin(), shape.end() - 1, new_shape.begin());
-    auto result = zeros<T>(new_shape);
+    auto result = zeros<T>(new_shape, tensor.order());
     auto nblocks = (result.size() + NUM_THREADS_X - 1) / NUM_THREADS_X;
     kernel_func<<<nblocks, NUM_THREADS_X>>>(_tensor, result);
     return result;

--- a/lib/math/sqrt.hpp
+++ b/lib/math/sqrt.hpp
@@ -15,7 +15,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, N> sqrt(const Tensor<T, N>& tensor) {
-    auto result = vt::zeros<T>(tensor.shape());
+    auto result = vt::zeros<T>(tensor.shape(), tensor.order());
     thrust::transform(tensor.begin(), tensor.end(), result.begin(), [] __device__(const T& x) {
         if constexpr (std::is_same<T, float>::value)
             return sqrtf(x);

--- a/lib/math/sum.hpp
+++ b/lib/math/sum.hpp
@@ -19,7 +19,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, 0> sum(const Tensor<T, N>& tensor) {
-    auto result = Tensor<T, 0>(Shape<0>{});
+    auto result = Tensor<T, 0>(Shape<0>{}, tensor.order());
     (*result.data())[0] = thrust::reduce(tensor.begin(), tensor.end(), (T)0, thrust::plus<T>());
     return result;
 }
@@ -33,7 +33,7 @@ Tensor<T, 0> sum(const Tensor<T, N>& tensor) {
  */
 template <size_t N>
 Tensor<int, 0> sum(const Tensor<bool, N>& tensor) {
-    auto result = Tensor<int, 0>(Shape<0>{});
+    auto result = Tensor<int, 0>(Shape<0>{}, tensor.order());
     (*result.data())[0] = thrust::reduce(tensor.begin(), tensor.end(), 0, thrust::plus<int>());
     return result;
 }
@@ -52,7 +52,7 @@ template <typename T, typename U, size_t N>
 __global__ void sum_along_axis_kernel(CuTensor<U, N> tensor, CuTensor<T, N - 1> result) {
     size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= result.size) return;
-    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start);
+    auto start = get_iterator_index<N - 1>(idx, tensor.shape, tensor.strides, tensor.start, tensor.order);
     auto sum = T{0};
     for (auto i = 0; i < tensor.shape[N - 1]; ++i) sum += tensor.data[start + i * tensor.strides[N - 1]];
     result[idx] = sum;

--- a/lib/math/tests/test_exp.cc
+++ b/lib/math/tests/test_exp.cc
@@ -2,8 +2,18 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Exp, BasicAssertions) {
-    auto tensor = vt::arange(6);
+TEST(ExpC, BasicAssertions) {
+    auto tensor = vt::arange(6).reshape(2, 3);
+    auto re = vt::exp(tensor);
+    auto s1 = vt::asvector(re);
+    auto s2 = std::vector<float>{1, 2.71828183, 7.3890561, 20.08553692, 54.59815003, 148.4131591};
+    for (auto i = 0; i < re.size(); ++i) {
+        EXPECT_NEAR(s1[i], s2[i], 1e-5);
+    }
+}
+
+TEST(ExpF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F).reshape(2, 3);
     auto re = vt::exp(tensor);
     auto s1 = vt::asvector(re);
     auto s2 = std::vector<float>{1, 2.71828183, 7.3890561, 20.08553692, 54.59815003, 148.4131591};

--- a/lib/math/tests/test_max.cc
+++ b/lib/math/tests/test_max.cc
@@ -2,13 +2,19 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Max, BasicAssertions) {
+TEST(MaxC, BasicAssertions) {
     auto tensor = vt::arange(12)({1, 12, 2});
     EXPECT_EQ(vt::asvector(vt::max(tensor)), std::vector<float>{11});
     EXPECT_EQ(vt::asvector(vt::max(tensor > 5.0f)), std::vector<bool>{true});
 }
 
-TEST(MaxAlongAxis, BasicAssertions) {
+TEST(MaxF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F)({1, 12, 2});
+    EXPECT_EQ(vt::asvector(vt::max(tensor)), std::vector<float>{11});
+    EXPECT_EQ(vt::asvector(vt::max(tensor > 5.0f)), std::vector<bool>{true});
+}
+
+TEST(MaxAlongAxisC, BasicAssertions) {
     auto tensor = vt::arange(72).reshape(6, 4, 3);
     auto tensor1 = tensor({2, 6, 2}, {0, 4, 2}, {0, 3});
     auto re = vt::max(tensor1, 0);
@@ -28,4 +34,26 @@ TEST(MaxAlongAxis, BasicAssertions) {
 
     re1 = vt::max(tensor1 > 40.0f, 2);
     EXPECT_EQ(vt::asvector(re1), (std::vector<bool>{0, 0, 1, 1}));
+}
+
+TEST(MaxAlongAxisF, BasicAssertions) {
+    auto tensor = vt::arange(72, vt::Order::F).reshape(6, 4, 3);
+    auto tensor1 = tensor({2, 6, 2}, {0, 4, 2}, {0, 3});
+    auto re = vt::max(tensor1, 0);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{4, 16, 28, 40, 52, 64}));
+
+    re = vt::max(tensor1, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{14, 16, 38, 40, 62, 64}));
+
+    re = vt::max(tensor1, 2);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{50, 52, 62, 64}));
+
+    auto re1 = vt::max(tensor1 > 40.0f, 0);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<bool>{0, 0, 0, 0, 1, 1}));
+
+    re1 = vt::max(tensor1 > 40.0f, 1);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<bool>{0, 0, 0, 0, 1, 1}));
+
+    re1 = vt::max(tensor1 > 40.0f, 2);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<bool>{1, 1, 1, 1}));
 }

--- a/lib/math/tests/test_maximum.cc
+++ b/lib/math/tests/test_maximum.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(MaximumBetweenTwoTensors, BasicAssertions) {
+TEST(MaximumBetweenTwoTensorsC, BasicAssertions) {
     auto tensor1 = vt::zeros(6) + 5.0f;
     auto tensor2 = vt::arange(12)({1, 12, 2});
     auto re = vt::maximum(tensor1, tensor2);
@@ -12,8 +12,27 @@ TEST(MaximumBetweenTwoTensors, BasicAssertions) {
     EXPECT_EQ(vt::asvector(re1), (std::vector<float>{5}));
 }
 
-TEST(MaximumBetweenTensorAndValue, BasicAssertions) {
+TEST(MaximumBetweenTwoTensorsF, BasicAssertions) {
+    auto tensor1 = (vt::zeros(6, vt::Order::F) + 5.0f).reshape(2, 3);
+    auto tensor2 = vt::arange(12, vt::Order::F)({1, 12, 2}).reshape(2, 3);
+    auto re = vt::maximum(tensor1, tensor2);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{5, 5, 5, 7, 9, 11}));
+
+    auto re1 = vt::maximum(tensor1[0][0], tensor2[0][0]);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<float>{5}));
+}
+
+TEST(MaximumBetweenTensorAndValueC, BasicAssertions) {
     auto tensor1 = vt::arange(12)({1, 12, 2});
+    auto re = vt::maximum(tensor1, 5.0f);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{5, 5, 5, 7, 9, 11}));
+
+    re = vt::maximum(5.0f, tensor1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{5, 5, 5, 7, 9, 11}));
+}
+
+TEST(MaximumBetweenTensorAndValueF, BasicAssertions) {
+    auto tensor1 = vt::arange(12, vt::Order::F)({1, 12, 2}).reshape(2, 3);
     auto re = vt::maximum(tensor1, 5.0f);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{5, 5, 5, 7, 9, 11}));
 

--- a/lib/math/tests/test_mean.cc
+++ b/lib/math/tests/test_mean.cc
@@ -2,13 +2,19 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Mean, BasicAssertions) {
+TEST(MeanC, BasicAssertions) {
     auto tensor = vt::arange(12)({1, 12, 3});
     EXPECT_EQ(vt::asvector(vt::mean(tensor)), std::vector<float>{5.5});
     EXPECT_EQ(vt::asvector(vt::mean(tensor > 5.0f)), std::vector<float>{0.5});
 }
 
-TEST(MeanAlongAxis, BasicAssertions) {
+TEST(MeanF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F)({1, 12, 3});
+    EXPECT_EQ(vt::asvector(vt::mean(tensor)), std::vector<float>{5.5});
+    EXPECT_EQ(vt::asvector(vt::mean(tensor > 5.0f)), std::vector<float>{0.5});
+}
+
+TEST(MeanAlongAxisC, BasicAssertions) {
     auto tensor = vt::arange(72).reshape(6, 4, 3);
     auto tensor1 = tensor({2, 6, 2}, {0, 4, 2}, {0, 3});
     auto re = vt::mean(tensor1, 0);
@@ -28,4 +34,26 @@ TEST(MeanAlongAxis, BasicAssertions) {
 
     re = vt::mean(tensor1 > 30.0f, 2);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 2.0f / 3, 1.0, 1.0}));
+}
+
+TEST(MeanAlongAxisF, BasicAssertions) {
+    auto tensor = vt::arange(72, vt::Order::F).reshape(6, 4, 3);
+    auto tensor1 = tensor({2, 6, 2}, {0, 4, 2}, {0, 3});
+    auto re = vt::mean(tensor1, 0);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{3, 15, 27, 39, 51, 63}));
+
+    re = vt::mean(tensor1, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{8, 10, 32, 34, 56, 58}));
+
+    re = vt::mean(tensor1, 2);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{26, 28, 38, 40}));
+
+    re = vt::mean(tensor1 > 30.0f, 0);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 0, 1.0, 1.0, 1.0}));
+
+    re = vt::mean(tensor1 > 30.0f, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 0, 0.5, 0.5, 1.0, 1.0}));
+
+    re = vt::mean(tensor1 > 30.0f, 2);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{1.0f / 3, 1.0f / 3, 2.0f / 3, 2.0f / 3}));
 }

--- a/lib/math/tests/test_min.cc
+++ b/lib/math/tests/test_min.cc
@@ -2,13 +2,19 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Min, BasicAssertions) {
+TEST(Min, BasicAssertionsC) {
     auto tensor = vt::arange(12)({1, 12, 2});
     EXPECT_EQ(vt::asvector(vt::min(tensor)), std::vector<float>{1});
     EXPECT_EQ(vt::asvector(vt::min(tensor > 5.0f)), std::vector<bool>{false});
 }
 
-TEST(MinAlongAxis, BasicAssertions) {
+TEST(Min, BasicAssertionsF) {
+    auto tensor = vt::arange(12, vt::Order::F)({1, 12, 2});
+    EXPECT_EQ(vt::asvector(vt::min(tensor)), std::vector<float>{1});
+    EXPECT_EQ(vt::asvector(vt::min(tensor > 5.0f)), std::vector<bool>{false});
+}
+
+TEST(MinAlongAxisC, BasicAssertions) {
     auto tensor = vt::arange(72).reshape(6, 4, 3);
     auto tensor1 = tensor({2, 6, 2}, {0, 4, 2}, {0, 3});
     auto re = vt::min(tensor1, 0);
@@ -28,4 +34,26 @@ TEST(MinAlongAxis, BasicAssertions) {
 
     re1 = vt::min(tensor1 > 40.0f, 2);
     EXPECT_EQ(vt::asvector(re1), (std::vector<bool>{0, 0, 1, 1}));
+}
+
+TEST(MinAlongAxisF, BasicAssertions) {
+    auto tensor = vt::arange(72, vt::Order::F).reshape(6, 4, 3);
+    auto tensor1 = tensor({2, 6, 2}, {0, 4, 2}, {0, 3});
+    auto re = vt::min(tensor1, 0);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{2, 14, 26, 38, 50, 62}));
+
+    re = vt::min(tensor1, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{2, 4, 26, 28, 50, 52}));
+
+    re = vt::min(tensor1, 2);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{2, 4, 14, 16}));
+
+    auto re1 = vt::min(tensor1 > 40.0f, 0);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<bool>{0, 0, 0, 0, 1, 1}));
+
+    re1 = vt::min(tensor1 > 40.0f, 1);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<bool>{0, 0, 0, 0, 1, 1}));
+
+    re1 = vt::min(tensor1 > 40.0f, 2);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<bool>{0, 0, 0, 0}));
 }

--- a/lib/math/tests/test_minimum.cc
+++ b/lib/math/tests/test_minimum.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(MinimumBetweenTwoTensors, BasicAssertions) {
+TEST(MinimumBetweenTwoTensorsC, BasicAssertions) {
     auto tensor1 = vt::zeros(6) + 5.0f;
     auto tensor2 = vt::arange(12)({1, 12, 2});
     auto re = vt::minimum(tensor1, tensor2);
@@ -12,8 +12,27 @@ TEST(MinimumBetweenTwoTensors, BasicAssertions) {
     EXPECT_EQ(vt::asvector(re1), (std::vector<float>{1}));
 }
 
-TEST(MinimumBetweenTensorAndValue, BasicAssertions) {
+TEST(MinimumBetweenTwoTensorsF, BasicAssertions) {
+    auto tensor1 = (vt::zeros(6, vt::Order::F) + 5.0f).reshape(2, 3);
+    auto tensor2 = vt::arange(12, vt::Order::F)({1, 12, 2}).reshape(2, 3);
+    auto re = vt::minimum(tensor1, tensor2);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 3, 5, 5, 5, 5}));
+
+    auto re1 = vt::minimum(tensor1[0][0], tensor2[0][0]);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<float>{1}));
+}
+
+TEST(MinimumBetweenTensorAndValueC, BasicAssertions) {
     auto tensor1 = vt::arange(12)({1, 12, 2});
+    auto re = vt::minimum(tensor1, 5.0f);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 3, 5, 5, 5, 5}));
+
+    re = vt::minimum(5.0f, tensor1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 3, 5, 5, 5, 5}));
+}
+
+TEST(MinimumBetweenTensorAndValueF, BasicAssertions) {
+    auto tensor1 = vt::arange(12)({1, 12, 2}).reshape(2, 3);
     auto re = vt::minimum(tensor1, 5.0f);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 3, 5, 5, 5, 5}));
 

--- a/lib/math/tests/test_power.cc
+++ b/lib/math/tests/test_power.cc
@@ -2,21 +2,40 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(PowerBetweenTwoTensors, BasicAssertions) {
+TEST(PowerBetweenTwoTensorsC, BasicAssertions) {
     auto tensor1 = vt::arange(6);
     auto tensor2 = vt::arange(6);
     auto re = vt::power(tensor1, tensor2);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 1, 4, 27, 256, 3125}));
 }
 
-TEST(PowerBetweenTensorAndValue, BasicAssertions) {
+TEST(PowerBetweenTwoTensorsF, BasicAssertions) {
+    auto tensor1 = vt::arange(6, vt::Order::F).reshape(2, 3);
+    auto tensor2 = vt::arange(6, vt::Order::F).reshape(2, 3);
+    auto re = vt::power(tensor1, tensor2);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 1, 4, 27, 256, 3125}));
+}
+
+TEST(PowerBetweenTensorAndValueC, BasicAssertions) {
     auto tensor1 = vt::arange(6);
     auto re = vt::power(tensor1, 2.0f);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 1, 4, 9, 16, 25}));
 }
 
-TEST(PowerBetweenValueAndTensor, BasicAssertions) {
+TEST(PowerBetweenTensorAndValueF, BasicAssertions) {
+    auto tensor1 = vt::arange(6, vt::Order::F).reshape(2, 3);
+    auto re = vt::power(tensor1, 2.0f);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 1, 4, 9, 16, 25}));
+}
+
+TEST(PowerBetweenValueAndTensorC, BasicAssertions) {
     auto tensor1 = vt::arange(6);
+    auto re = vt::power(2.0f, tensor1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 2, 4, 8, 16, 32}));
+}
+
+TEST(PowerBetweenValueAndTensorF, BasicAssertions) {
+    auto tensor1 = vt::arange(6, vt::Order::F).reshape(2, 3);
     auto re = vt::power(2.0f, tensor1);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 2, 4, 8, 16, 32}));
 }

--- a/lib/math/tests/test_sort.cc
+++ b/lib/math/tests/test_sort.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Sort, BasicAssertions) {
+TEST(SortC, BasicAssertions) {
     auto tensor = vt::arange(12)({1, 12, 2}).reshape(2, 3);
     auto re = vt::sort(tensor);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 3, 5, 7, 9, 11}));
@@ -12,7 +12,17 @@ TEST(Sort, BasicAssertions) {
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 3, 5, 7, 9, 11}));
 }
 
-TEST(SortlongAxis, BasicAssertions) {
+TEST(SortF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F)({1, 12, 2}).reshape(2, 3);
+    auto re = vt::sort(tensor);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 3, 5, 7, 9, 11}));
+
+    tensor = vt::arange(12.0f, 0.0f, -1.0f, vt::Order::F)({1, 12, 2}).reshape(2, 3);
+    re = vt::sort(tensor);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{1, 3, 5, 7, 9, 11}));
+}
+
+TEST(SortlongAxisC, BasicAssertions) {
     auto tensor = vt::arange(12.0f, 0.0f, -1.0f).reshape(2, 2, 3);
     auto re = vt::sort(tensor, 0);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{6, 5, 4, 3, 2, 1, 12, 11, 10, 9, 8, 7}));
@@ -22,4 +32,16 @@ TEST(SortlongAxis, BasicAssertions) {
 
     re = vt::sort(tensor, 2);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{10, 11, 12, 7, 8, 9, 4, 5, 6, 1, 2, 3}));
+}
+
+TEST(SortlongAxisF, BasicAssertions) {
+    auto tensor = vt::arange(12.0f, 0.0f, -1.0f, vt::Order::F).reshape(2, 2, 3);
+    auto re = vt::sort(tensor, 0);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{11, 12, 9, 10, 7, 8, 5, 6, 3, 4, 1, 2}));
+
+    re = vt::sort(tensor, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{10, 9, 12, 11, 6, 5, 8, 7, 2, 1, 4, 3}));
+
+    re = vt::sort(tensor, 2);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{4, 3, 2, 1, 8, 7, 6, 5, 12, 11, 10, 9}));
 }

--- a/lib/math/tests/test_sqrt.cc
+++ b/lib/math/tests/test_sqrt.cc
@@ -2,8 +2,15 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(SqrtForTensor, BasicAssertions) {
+TEST(SqrtForTensorC, BasicAssertions) {
     auto tensor = vt::arange(6);
+    auto re = vt::power(tensor, 2.0f);
+    re = vt::sqrt(re);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 1, 2, 3, 4, 5}));
+}
+
+TEST(SqrtForTensorF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F).reshape(2, 3);
     auto re = vt::power(tensor, 2.0f);
     re = vt::sqrt(re);
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{0, 1, 2, 3, 4, 5}));

--- a/lib/math/tests/test_sum.cc
+++ b/lib/math/tests/test_sum.cc
@@ -2,13 +2,19 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Sum, BasicAssertions) {
+TEST(SumC, BasicAssertions) {
     auto tensor = vt::arange(12)({1, 12, 2});
     EXPECT_EQ(vt::asvector(vt::sum(tensor)), std::vector<float>{36});
     EXPECT_EQ(vt::asvector(vt::sum(tensor > 5.0f)), std::vector<int>{3});
 }
 
-TEST(SumAlongAxis, BasicAssertions) {
+TEST(SumF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F)({1, 12, 2});
+    EXPECT_EQ(vt::asvector(vt::sum(tensor)), std::vector<float>{36});
+    EXPECT_EQ(vt::asvector(vt::sum(tensor > 5.0f)), std::vector<int>{3});
+}
+
+TEST(SumAlongAxisC, BasicAssertions) {
     auto tensor = vt::arange(72).reshape(6, 4, 3);
     auto tensor1 = tensor({2, 6, 2}, {0, 4, 2}, {0, 3});
     auto re = vt::sum(tensor1, 0);
@@ -28,4 +34,26 @@ TEST(SumAlongAxis, BasicAssertions) {
 
     re1 = vt::sum(tensor1 > 30.0f, 2);
     EXPECT_EQ(vt::asvector(re1), (std::vector<int>{0, 2, 3, 3}));
+}
+
+TEST(SumAlongAxisF, BasicAssertions) {
+    auto tensor = vt::arange(72, vt::Order::F).reshape(6, 4, 3);
+    auto tensor1 = tensor({2, 6, 2}, {0, 4, 2}, {0, 3});
+    auto re = vt::sum(tensor1, 0);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{6, 30, 54, 78, 102, 126}));
+
+    re = vt::sum(tensor1, 1);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{16, 20, 64, 68, 112, 116}));
+
+    re = vt::sum(tensor1, 2);
+    EXPECT_EQ(vt::asvector(re), (std::vector<float>{78, 84, 114, 120}));
+
+    auto re1 = vt::sum(tensor1 > 30.0f, 0);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<int>{0, 0, 0, 2, 2, 2}));
+
+    re1 = vt::sum(tensor1 > 30.0f, 1);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<int>{0, 0, 1, 1, 2, 2}));
+
+    re1 = vt::sum(tensor1 > 30.0f, 2);
+    EXPECT_EQ(vt::asvector(re1), (std::vector<int>{1, 1, 2, 2}));
 }

--- a/lib/math/tests/test_transpose.cc
+++ b/lib/math/tests/test_transpose.cc
@@ -2,13 +2,14 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Transpose, BasicAssertions) {
+TEST(TransposeC, BasicAssertions) {
     auto tensor = vt::arange(12).reshape(3, 2, 2);
     auto tensor1 = vt::transpose(tensor);
     EXPECT_EQ(tensor.size(), 12);
     EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{3, 2, 2}));
     EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{4, 2, 1}));
     EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::C);
     EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 
@@ -16,12 +17,34 @@ TEST(Transpose, BasicAssertions) {
     EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{2, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{1, 2, 4}));
     EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.contiguous(), false);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 4, 8, 2, 6, 10, 1, 5, 9, 3, 7, 11}));
 }
 
-TEST(TransposeWithAxis, BasicAssertions) {
+TEST(TransposeF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F).reshape(3, 2, 2);
+    auto tensor1 = vt::transpose(tensor);
+    EXPECT_EQ(tensor.size(), 12);
+    EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{3, 2, 2}));
+    EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{1, 3, 6}));
+    EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::F);
+    EXPECT_EQ(tensor.contiguous(), true);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+
+    EXPECT_EQ(tensor1.size(), 12);
+    EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{2, 2, 3}));
+    EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{6, 3, 1}));
+    EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.contiguous(), false);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 6, 3, 9, 1, 7, 4, 10, 2, 8, 5, 11}));
+}
+
+TEST(TransposeWithAxisC, BasicAssertions) {
     auto tensor = vt::arange(12).reshape(3, 2, 2);
     auto tensor1 = vt::transpose(tensor, {2, 1, 0});
 
@@ -29,6 +52,7 @@ TEST(TransposeWithAxis, BasicAssertions) {
     EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{3, 2, 2}));
     EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{4, 2, 1}));
     EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::C);
     EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 
@@ -36,12 +60,35 @@ TEST(TransposeWithAxis, BasicAssertions) {
     EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{2, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{1, 2, 4}));
     EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.contiguous(), false);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 4, 8, 2, 6, 10, 1, 5, 9, 3, 7, 11}));
 }
 
-TEST(MoveAxis, BasicAssertions) {
+TEST(TransposeWithAxisF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F).reshape(3, 2, 2);
+    auto tensor1 = vt::transpose(tensor, {2, 1, 0});
+
+    EXPECT_EQ(tensor.size(), 12);
+    EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{3, 2, 2}));
+    EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{1, 3, 6}));
+    EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::F);
+    EXPECT_EQ(tensor.contiguous(), true);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+
+    EXPECT_EQ(tensor1.size(), 12);
+    EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{2, 2, 3}));
+    EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{6, 3, 1}));
+    EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.contiguous(), false);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 6, 3, 9, 1, 7, 4, 10, 2, 8, 5, 11}));
+}
+
+TEST(MoveAxisC, BasicAssertions) {
     auto tensor = vt::arange(12).reshape(3, 2, 2);
     auto tensor1 = vt::moveaxis(tensor, 0, 2);
     tensor1 = vt::moveaxis(tensor1, 0, 1);
@@ -50,6 +97,7 @@ TEST(MoveAxis, BasicAssertions) {
     EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{3, 2, 2}));
     EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{4, 2, 1}));
     EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::C);
     EXPECT_EQ(tensor.contiguous(), true);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 
@@ -57,13 +105,43 @@ TEST(MoveAxis, BasicAssertions) {
     EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{2, 2, 3}));
     EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{1, 2, 4}));
     EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::C);
     EXPECT_EQ(tensor1.contiguous(), false);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 4, 8, 2, 6, 10, 1, 5, 9, 3, 7, 11}));
 }
 
-TEST(Swapaxes, BasicAssertions) {
+TEST(MoveAxisF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F).reshape(3, 2, 2);
+    auto tensor1 = vt::moveaxis(tensor, 0, 2);
+    tensor1 = vt::moveaxis(tensor1, 0, 1);
+
+    EXPECT_EQ(tensor.size(), 12);
+    EXPECT_EQ(tensor.shape(), (std::array<size_t, 3>{3, 2, 2}));
+    EXPECT_EQ(tensor.strides(), (std::array<size_t, 3>{1, 3, 6}));
+    EXPECT_EQ(tensor.start(), 0);
+    EXPECT_EQ(tensor.order(), vt::Order::F);
+    EXPECT_EQ(tensor.contiguous(), true);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+
+    EXPECT_EQ(tensor1.size(), 12);
+    EXPECT_EQ(tensor1.shape(), (std::array<size_t, 3>{2, 2, 3}));
+    EXPECT_EQ(tensor1.strides(), (std::array<size_t, 3>{6, 3, 1}));
+    EXPECT_EQ(tensor1.start(), 0);
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
+    EXPECT_EQ(tensor1.contiguous(), false);
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 6, 3, 9, 1, 7, 4, 10, 2, 8, 5, 11}));
+}
+
+TEST(SwapaxesC, BasicAssertions) {
     auto tensor = vt::arange(24)({0, 24, 2}).reshape(3, 4);
     auto tensor2 = vt::swapaxes(tensor, 0, 1);
     EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 8, 16, 2, 10, 18, 4, 12, 20, 6, 14, 22}));
+}
+
+TEST(SwapaxesF, BasicAssertions) {
+    auto tensor = vt::arange(24, vt::Order::F)({0, 24, 2}).reshape(3, 4);
+    auto tensor2 = vt::swapaxes(tensor, 0, 1);
+    EXPECT_EQ(vt::asvector(tensor2), (std::vector<float>{0, 6, 12, 18, 2, 8, 14, 20, 4, 10, 16, 22}));
 }

--- a/lib/math/tests/test_vander.cc
+++ b/lib/math/tests/test_vander.cc
@@ -2,8 +2,14 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Vander, BasicAssertions) {
+TEST(VanderC, BasicAssertions) {
     auto tensor = vt::arange(6);
     auto v = vt::vander(tensor, 2);
     EXPECT_EQ(vt::asvector(v), (std::vector<float>{0, 0, 1, 1, 1, 1, 4, 2, 1, 9, 3, 1, 16, 4, 1, 25, 5, 1}));
+}
+
+TEST(VanderF, BasicAssertions) {
+    auto tensor = vt::arange(6, vt::Order::F);
+    auto v = vt::vander(tensor, 2);
+    EXPECT_EQ(vt::asvector(v), (std::vector<float>{0, 1, 4, 9, 16, 25, 0, 1, 2, 3, 4, 5, 1, 1, 1, 1, 1, 1}));
 }

--- a/lib/math/transpose.hpp
+++ b/lib/math/transpose.hpp
@@ -23,7 +23,7 @@ Tensor<T, N> transpose(const Tensor<T, N>& tensor) {
         new_shape[i] = shape[N - i - 1];
         new_strides[i] = strides[N - i - 1];
     }
-    return Tensor(tensor.data(), new_shape, new_strides, tensor.start(), false);
+    return Tensor(tensor.data(), new_shape, new_strides, tensor.start(), tensor.order(), false);
 }
 
 /**
@@ -46,7 +46,7 @@ Tensor<T, N> transpose(const Tensor<T, N>& tensor, const Shape<N>& axes) {
         new_shape[i] = shape[axes[i]];
         new_strides[i] = strides[axes[i]];
     }
-    return Tensor(tensor.data(), new_shape, new_strides, tensor.start(), false);
+    return Tensor(tensor.data(), new_shape, new_strides, tensor.start(), tensor.order(), false);
 }
 
 /**

--- a/lib/math/vander.hpp
+++ b/lib/math/vander.hpp
@@ -16,7 +16,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, N + 1> vander(const Tensor<T, N>& x, const int degree) {
-    auto seq = arange(static_cast<T>(degree), T{-1.0}, T{-1.0});
+    auto seq = arange(static_cast<T>(degree), T{-1.0}, T{-1.0}, x.order());
     auto _seq = expand_dims_lhs<T, 1, N>(seq);
     auto _x = expand_dims_rhs<T, N, 1>(x);
     auto re = power(_x, _seq);

--- a/lib/memory/asfortrantensor.hpp
+++ b/lib/memory/asfortrantensor.hpp
@@ -22,7 +22,7 @@ Tensor<T, 2> asfortrantensor(Tensor<T, 2>& tensor) {
     auto shape = ctensor.shape();
     int m = shape[0];
     int n = shape[1];
-    auto result = zeros<T>(shape);
+    auto result = zeros<T>(shape, Order::F);
     auto handle = cuda::cublas.get_handle();
     auto alpha = T{1.0};
     auto beta = T{0.0};

--- a/lib/memory/asxarray.hpp
+++ b/lib/memory/asxarray.hpp
@@ -10,27 +10,33 @@ namespace vt {
 /**
  * @brief Copy a tensor from device to host array.
  *
- * @param tensor: The tensor object.
  * @tparam T: Data type of the tensor.
  * @tparam N: Number of dimensions of the tensor.
+ * @tparam L: Layout type of the tensor.
+ * @param tensor: The tensor object.
  * @return xt::xarray<T>: Host array.
  */
-template <typename T, size_t N>
+template <typename T, size_t N, xt::layout_type L>
 xt::xarray<T> asxarray(const Tensor<T, N>& tensor) {
-    auto s = tensor.shape();
-    std::vector<size_t> shape(s.begin(), s.end());
-    xt::xarray<T> arr(shape);
-    if constexpr (std::is_same_v<T, bool>) {
-        thrust::copy(tensor.begin(), tensor.end(), arr.begin());
-    } else {
-        if (tensor.contiguous()) {
-            auto s = tensor.size() * sizeof(T);
-            cudaMemcpy(arr.data(), tensor.raw_ptr(), s, cudaMemcpyDeviceToHost);
-        } else {
+    auto order = tensor.order();
+    if ((order == Order::C && L == xt::layout_type::row_major) || (order == Order::F && L == xt::layout_type::column_major)) {
+        auto s = tensor.shape();
+        std::vector<size_t> shape(s.begin(), s.end());
+        xt::xarray<T, L> arr(shape);
+        if constexpr (std::is_same_v<T, bool>) {
             thrust::copy(tensor.begin(), tensor.end(), arr.begin());
+        } else {
+            if (tensor.contiguous()) {
+                auto s = tensor.size() * sizeof(T);
+                cudaMemcpy(arr.data(), tensor.raw_ptr(), s, cudaMemcpyDeviceToHost);
+            } else {
+                thrust::copy(tensor.begin(), tensor.end(), arr.begin());
+            }
         }
+        return arr;
+    } else {
+        throw std::runtime_error("The order of the tensor is not compatible with the layout type.");
     }
-    return arr;
 }
 
 }  // namespace vt

--- a/lib/memory/copy.hpp
+++ b/lib/memory/copy.hpp
@@ -15,7 +15,7 @@ namespace vt {
  */
 template <typename T, size_t N>
 Tensor<T, N> copy(const Tensor<T, N>& tensor) {
-    auto tensor_cp = zeros<T>(tensor.shape());
+    auto tensor_cp = zeros<T>(tensor.shape(), tensor.order());
     thrust::copy(tensor.begin(), tensor.end(), tensor_cp.begin());
     return tensor_cp;
 }

--- a/lib/memory/fileio.hpp
+++ b/lib/memory/fileio.hpp
@@ -19,19 +19,26 @@ namespace vt {
  */
 template <typename T, size_t N>
 void save(const std::string& filename, const Tensor<T, N>& tensor) {
-    xt::dump_npy(filename, asxarray(tensor));
+    auto order = tensor.order();
+    if (order == Order::C) {
+        xt::dump_npy(filename, asxarray<T, N, xt::layout_type::row_major>(tensor));
+    } else {
+        xt::dump_npy(filename, asxarray<T, N, xt::layout_type::column_major>(tensor));
+    }
 }
 
 /**
  * @brief Load tensor from a file.
  *
  * @tparam T: Data type of the tensor.
+ * @tparam N: Number of dimensions of the tensor.
+ * @tparam L: Layout type of the tensor.
  * @param filename: Name of the file.
- * @return Tensor<T, 1>: The tensor loaded from the file.
+ * @return Tensor<T, N>: The tensor loaded from the file.
  */
-template <typename T, size_t N>
+template <typename T, size_t N, xt::layout_type L>
 Tensor<T, N> load(const std::string& filename) {
-    return astensor<T, N>(xt::load_npy<T>(filename));
+    return astensor<T, N, L>(xt::load_npy<T>(filename));
 }
 
 }  // namespace vt

--- a/lib/memory/tests/test_asfortrantensor.cc
+++ b/lib/memory/tests/test_asfortrantensor.cc
@@ -7,8 +7,10 @@ TEST(ConvertToFortranTensor, BasicAssertions) {
     auto tensor1 = vt::asfortrantensor(tensor);
     EXPECT_EQ(tensor.shape(), (std::array<size_t, 2>{2, 3}));
     EXPECT_EQ(tensor.strides(), (std::array<size_t, 2>{3, 1}));
+    EXPECT_EQ(tensor.order(), vt::Order::C);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10}));
     EXPECT_EQ(tensor1.shape(), (std::array<size_t, 2>{2, 3}));
     EXPECT_EQ(tensor1.strides(), (std::array<size_t, 2>{1, 2}));
+    EXPECT_EQ(tensor1.order(), vt::Order::F);
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{0, 6, 2, 8, 4, 10}));
 }

--- a/lib/memory/tests/test_astensor.cc
+++ b/lib/memory/tests/test_astensor.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(CopyFromHostToDevice, BasicAssertions) {
+TEST(CopyFromHostToDeviceC, BasicAssertions) {
     std::vector<float> vector{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
     auto tensor = vt::astensor(vector);
     EXPECT_EQ(vt::asvector(tensor), vector);
@@ -10,5 +10,18 @@ TEST(CopyFromHostToDevice, BasicAssertions) {
     EXPECT_EQ(vt::asvector(tensor1), vector);
     auto arr = xt::xarray<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
     auto tensor2 = vt::astensor<float, 1>(arr);
-    EXPECT_EQ(vt::asxarray(tensor2), arr);
+    auto arr1 = vt::asxarray<float, 1, xt::layout_type::row_major>(tensor2);
+    EXPECT_EQ(arr, arr1);
+}
+
+TEST(CopyFromHostToDeviceF, BasicAssertions) {
+    std::vector<float> vector{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    auto tensor = vt::astensor(vector, vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor), vector);
+    auto tensor1 = vt::astensor(vector.data(), vector.size(), vt::Order::F);
+    EXPECT_EQ(vt::asvector(tensor1), vector);
+    auto arr = xt::xarray<float, xt::layout_type::column_major>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+    auto tensor2 = vt::astensor<float, 1>(arr);
+    auto arr2 = vt::asxarray<float, 1, xt::layout_type::column_major>(tensor2);
+    EXPECT_EQ(arr, arr2);
 }

--- a/lib/memory/tests/test_asvector.cc
+++ b/lib/memory/tests/test_asvector.cc
@@ -2,8 +2,14 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(CopyFromDeviceToHost, BasicAssertions) {
+TEST(CopyFromDeviceToHostC, BasicAssertions) {
     auto tensor = vt::arange(12);
+    auto vector = vt::asvector(tensor);
+    EXPECT_EQ(vector, (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+}
+
+TEST(CopyFromDeviceToHostF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F);
     auto vector = vt::asvector(tensor);
     EXPECT_EQ(vector, (std::vector<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
 }

--- a/lib/memory/tests/test_asxarray.cc
+++ b/lib/memory/tests/test_asxarray.cc
@@ -2,8 +2,16 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(CopyFromDeviceToHostXArray, BasicAssertions) {
+TEST(CopyFromDeviceToHostXArrayC, BasicAssertions) {
     auto tensor = vt::arange(12);
-    auto arr = vt::asxarray(tensor);
-    EXPECT_EQ(arr, (xt::xarray<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+    auto arr = (xt::xarray<float>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+    auto arr1 = vt::asxarray<float, 1, xt::layout_type::row_major>(tensor);
+    EXPECT_EQ(arr, arr1);
+}
+
+TEST(CopyFromDeviceToHostXArrayF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F);
+    auto arr = (xt::xarray<float, xt::layout_type::column_major>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11});
+    auto arr1 = vt::asxarray<float, 1, xt::layout_type::column_major>(tensor);
+    EXPECT_EQ(arr, arr1);
 }

--- a/lib/memory/tests/test_copy.cc
+++ b/lib/memory/tests/test_copy.cc
@@ -2,8 +2,14 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(CopyFromDeviceToDevice, BasicAssertions) {
+TEST(CopyFromDeviceToDeviceC, BasicAssertions) {
     auto tensor = vt::arange(12)({1, 12, 2});
+    auto tensor1 = vt::copy(tensor);
+    EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 3, 5, 7, 9, 11}));
+}
+
+TEST(CopyFromDeviceToDeviceF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F)({1, 12, 2});
     auto tensor1 = vt::copy(tensor);
     EXPECT_EQ(vt::asvector(tensor1), (std::vector<float>{1, 3, 5, 7, 9, 11}));
 }

--- a/lib/memory/tests/test_fileio.cc
+++ b/lib/memory/tests/test_fileio.cc
@@ -2,9 +2,16 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(IO, BasicAssertions) {
-    auto tensor = vt::arange(12);
+TEST(IOC, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(2, 2, 3);
     vt::save("test.npy", tensor);
-    auto tensor1 = vt::load<float, 1>("test.npy");
+    auto tensor1 = vt::load<float, 3, xt::layout_type::row_major>("test.npy");
+    EXPECT_EQ(vt::asvector(tensor), vt::asvector(tensor1));
+}
+
+TEST(IOF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F).reshape(2, 2, 3);
+    vt::save("test.npy", tensor);
+    auto tensor1 = vt::load<float, 3, xt::layout_type::column_major>("test.npy");
     EXPECT_EQ(vt::asvector(tensor), vt::asvector(tensor1));
 }

--- a/lib/random/normal.hpp
+++ b/lib/random/normal.hpp
@@ -15,12 +15,13 @@ namespace random {
  * @param shape: Shape of the tensor.
  * @param mean: Mean of the normal distribution.
  * @param stddev: Standard deviation of the normal distribution.
+ * @param order: Order of the tensor.
  * @param gen: The CuRand generator. The default is the global CuRand generator.
  * @return Tensor<T, N>: The tensor of random numbers.
  */
 template <typename T = float, size_t N>
-Tensor<T, N> normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, curandGenerator_t gen = cuda::curand.get_handle()) {
-    auto tensor = Tensor<T, N>(shape);
+Tensor<T, N> normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+    auto tensor = Tensor<T, N>(shape, order);
     curandStatus_t status;
     if constexpr (std::is_same<T, float>::value) {
         status = curandGenerateNormal(gen, tensor.raw_ptr(), tensor.size(), mean, stddev);
@@ -38,13 +39,14 @@ Tensor<T, N> normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, curandGe
  * @param m: Size of the tensor.
  * @param mean: Mean of the normal distribution.
  * @param stddev: Standard deviation of the normal distribution.
+ * @param order: Order of the tensor.
  * @param gen: The CuRand generator. The default is the global CuRand generator.
  * @return Tensor<T, 1>: The tensor of random numbers.
  */
 template <typename T = float>
-Tensor<T, 1> normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, curandGenerator_t gen = cuda::curand.get_handle()) {
+Tensor<T, 1> normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
     auto shape = Shape<1>{m};
-    return normal<T, 1>(shape, mean, stddev, gen);
+    return normal<T, 1>(shape, mean, stddev, order, gen);
 }
 
 /**
@@ -55,13 +57,14 @@ Tensor<T, 1> normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, curandGenerato
  * @param n: Number of columns of the tensor.
  * @param mean: Mean of the normal distribution.
  * @param stddev: Standard deviation of the normal distribution.
+ * @param order: Order of the tensor.
  * @param gen: The CuRand generator. The default is the global CuRand generator.
  * @return Tensor<T, 2>: The tensor of random numbers.
  */
 template <typename T = float>
-Tensor<T, 2> normal(size_t m, size_t n, T mean = T{0.0}, T stddev = T{1.0}, curandGenerator_t gen = cuda::curand.get_handle()) {
+Tensor<T, 2> normal(size_t m, size_t n, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
     auto shape = Shape<2>{m, n};
-    return normal<T, 2>(shape, mean, stddev, gen);
+    return normal<T, 2>(shape, mean, stddev, order, gen);
 }
 
 }  // namespace random

--- a/lib/random/rand.hpp
+++ b/lib/random/rand.hpp
@@ -13,12 +13,13 @@ namespace random {
  * @tparam T: Data type of the tensor.
  * @tparam N: Number of dimensions of the tensor.
  * @param shape: Shape of the tensor.
+ * @param order: Order of the tensor.
  * @param gen: The CuRand generator. The default is the global CuRand generator.
  * @return Tensor<T, N>: The tensor of random numbers.
  */
 template <typename T = float, size_t N>
-Tensor<T, N> rand(Shape<N> shape, curandGenerator_t gen = cuda::curand.get_handle()) {
-    auto tensor = Tensor<T, N>(shape);
+Tensor<T, N> rand(Shape<N> shape, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+    auto tensor = Tensor<T, N>(shape, order);
     curandStatus_t status;
     if constexpr (std::is_same<T, float>::value) {
         status = curandGenerateUniform(gen, tensor.raw_ptr(), tensor.size());
@@ -34,12 +35,13 @@ Tensor<T, N> rand(Shape<N> shape, curandGenerator_t gen = cuda::curand.get_handl
  *
  * @tparam T: Data type of the tensor.
  * @param m: Size of the tensor.
+ * @param order: Order of the tensor.
  * @param gen: The CuRand generator. The default is the global CuRand generator.
  * @return Tensor<T, 1>: The tensor of random numbers.
  */
 template <typename T = float>
-Tensor<T, 1> rand(size_t m, curandGenerator_t gen = cuda::curand.get_handle()) {
-    return rand<T, 1>({m}, gen);
+Tensor<T, 1> rand(size_t m, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+    return rand<T, 1>({m}, order, gen);
 }
 
 /**
@@ -48,12 +50,13 @@ Tensor<T, 1> rand(size_t m, curandGenerator_t gen = cuda::curand.get_handle()) {
  * @tparam T: Data type of the tensor.
  * @param m: Number of rows of the tensor.
  * @param n: Number of columns of the tensor.
+ * @param order: Order of the tensor.
  * @param gen: The CuRand generator. The default is the global CuRand generator.
  * @return Tensor<T, 2>: The tensor of random numbers.
  */
 template <typename T = float>
-Tensor<T, 2> rand(size_t m, size_t n, curandGenerator_t gen = cuda::curand.get_handle()) {
-    return rand<T, 2>({m, n}, gen);
+Tensor<T, 2> rand(size_t m, size_t n, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+    return rand<T, 2>({m, n}, order, gen);
 }
 
 }  // namespace random

--- a/lib/random/tests/test_normal.cc
+++ b/lib/random/tests/test_normal.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Normal, BasicAssertions) {
+TEST(NormalC, BasicAssertions) {
     // Set the seed and offset to the original state
     vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
     vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
@@ -25,9 +25,32 @@ TEST(Normal, BasicAssertions) {
     cudaFree(d_data);
 }
 
-TEST(QusiNormal, BasicAssertions) {
+TEST(NormalF, BasicAssertions) {
+    // Set the seed and offset to the original state
+    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+
+    auto shape = vt::Shape<1>{10};
+    auto tensor = vt::random::normal(shape, 0.0f, 1.0f, vt::Order::F);
+
+    float* d_data;
+    auto h_data = std::vector<float>(10);
+    cudaMalloc(&d_data, 10 * sizeof(float));
+
+    curandGenerator_t gen1;
+    curandCreateGenerator(&gen1, CURAND_RNG_PSEUDO_DEFAULT);
+    curandGenerateNormal(gen1, d_data, 10, 0, 1);
+    cudaMemcpy(h_data.data(), d_data, 10 * sizeof(float), cudaMemcpyDeviceToHost);
+
+    auto vec = vt::asvector(tensor);
+    for (size_t i = 0; i < 10; i++) EXPECT_EQ(vec[i], h_data[i]);
+    curandDestroyGenerator(gen1);
+    cudaFree(d_data);
+}
+
+TEST(QusiNormalC, BasicAssertions) {
     auto gen = vt::cuda::create_curand_handle<vt::cuda::SCRAMBLED_SOBOL32>(2);
-    auto tensor = vt::random::normal(10, 0.0f, 1.0f, *gen.get());
+    auto tensor = vt::random::normal(10, 0.0f, 1.0f, vt::Order::C, *gen.get());
 
     float* d_data;
     auto h_data = std::vector<float>(10);
@@ -45,7 +68,27 @@ TEST(QusiNormal, BasicAssertions) {
     cudaFree(d_data);
 }
 
-TEST(Normal1D, BasicAssertions) {
+TEST(QusiNormalF, BasicAssertions) {
+    auto gen = vt::cuda::create_curand_handle<vt::cuda::SCRAMBLED_SOBOL32>(2);
+    auto tensor = vt::random::normal(10, 0.0f, 1.0f, vt::Order::F, *gen.get());
+
+    float* d_data;
+    auto h_data = std::vector<float>(10);
+    cudaMalloc(&d_data, 10 * sizeof(float));
+
+    curandGenerator_t gen1;
+    curandCreateGenerator(&gen1, CURAND_RNG_QUASI_SCRAMBLED_SOBOL32);
+    curandSetQuasiRandomGeneratorDimensions(gen1, 2);
+    curandGenerateNormal(gen1, d_data, 10, 0.0, 1.0);
+    cudaMemcpy(h_data.data(), d_data, 10 * sizeof(float), cudaMemcpyDeviceToHost);
+    auto vec = vt::asvector(tensor);
+    for (size_t i = 0; i < 10; i++) EXPECT_EQ(vec[i], h_data[i]);
+
+    curandDestroyGenerator(gen1);
+    cudaFree(d_data);
+}
+
+TEST(Normal1DC, BasicAssertions) {
     // Set the seed and offset to the original state
     vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
     vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
@@ -56,11 +99,26 @@ TEST(Normal1D, BasicAssertions) {
 
     // Generate from local
     auto gen = vt::cuda::create_curand_handle();
-    auto tensor2 = vt::random::normal(10, 0.0f, 1.0f, *gen.get());
+    auto tensor2 = vt::random::normal(10, 0.0f, 1.0f, vt::Order::C, *gen.get());
     EXPECT_EQ(vt::asvector(tensor1), vt::asvector(tensor2));
 }
 
-TEST(Normal2D, BasicAssertions) {
+TEST(Normal1DF, BasicAssertions) {
+    // Set the seed and offset to the original state
+    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+
+    // Generate from global
+    auto shape = vt::Shape<1>{10};
+    auto tensor1 = vt::random::normal(shape, 0.0f, 1.0f, vt::Order::F);
+
+    // Generate from local
+    auto gen = vt::cuda::create_curand_handle();
+    auto tensor2 = vt::random::normal(10, 0.0f, 1.0f, vt::Order::F, *gen.get());
+    EXPECT_EQ(vt::asvector(tensor1), vt::asvector(tensor2));
+}
+
+TEST(Normal2DC, BasicAssertions) {
     // Set the seed and offset to the original state
     vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
     vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
@@ -71,6 +129,21 @@ TEST(Normal2D, BasicAssertions) {
 
     // Generate from local
     auto gen = vt::cuda::create_curand_handle();
-    auto tensor2 = vt::random::normal(2, 5, 0.0f, 1.0f, *gen.get());
+    auto tensor2 = vt::random::normal(2, 5, 0.0f, 1.0f, vt::Order::C, *gen.get());
+    EXPECT_EQ(vt::asvector(tensor1), vt::asvector(tensor2));
+}
+
+TEST(Normal2DF, BasicAssertions) {
+    // Set the seed and offset to the original state
+    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+
+    // Generate from global
+    auto shape = vt::Shape<1>{10};
+    auto tensor1 = vt::random::normal(shape, 0.0f, 1.0f, vt::Order::F);
+
+    // Generate from local
+    auto gen = vt::cuda::create_curand_handle();
+    auto tensor2 = vt::random::normal(2, 5, 0.0f, 1.0f, vt::Order::F, *gen.get());
     EXPECT_EQ(vt::asvector(tensor1), vt::asvector(tensor2));
 }

--- a/lib/random/tests/test_rand.cc
+++ b/lib/random/tests/test_rand.cc
@@ -2,7 +2,7 @@
 
 #include <lib/vtensor.hpp>
 
-TEST(Rand, BasicAssertions) {
+TEST(RandC, BasicAssertions) {
     // Set the seed and offset to the original state
     vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
     vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
@@ -25,9 +25,32 @@ TEST(Rand, BasicAssertions) {
     cudaFree(d_data);
 }
 
-TEST(QusiRand, BasicAssertions) {
+TEST(RandF, BasicAssertions) {
+    // Set the seed and offset to the original state
+    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+
+    auto shape = vt::Shape<1>{10};
+    auto tensor = vt::random::rand(shape, vt::Order::F);
+
+    float* d_data;
+    auto h_data = std::vector<float>(10);
+    cudaMalloc(&d_data, 10 * sizeof(float));
+
+    curandGenerator_t gen1;
+    curandCreateGenerator(&gen1, CURAND_RNG_PSEUDO_DEFAULT);
+    curandGenerateUniform(gen1, d_data, 10);
+    cudaMemcpy(h_data.data(), d_data, 10 * sizeof(float), cudaMemcpyDeviceToHost);
+
+    auto vec = vt::asvector(tensor);
+    for (size_t i = 0; i < 10; i++) EXPECT_EQ(vec[i], h_data[i]);
+    curandDestroyGenerator(gen1);
+    cudaFree(d_data);
+}
+
+TEST(QusiRandC, BasicAssertions) {
     auto gen = vt::cuda::create_curand_handle<vt::cuda::SCRAMBLED_SOBOL32>(2);
-    auto tensor = vt::random::rand(10, *gen.get());
+    auto tensor = vt::random::rand(10, vt::Order::C, *gen.get());
 
     float* d_data;
     auto h_data = std::vector<float>(10);
@@ -45,7 +68,27 @@ TEST(QusiRand, BasicAssertions) {
     cudaFree(d_data);
 }
 
-TEST(Rand1D, BasicAssertions) {
+TEST(QusiRandF, BasicAssertions) {
+    auto gen = vt::cuda::create_curand_handle<vt::cuda::SCRAMBLED_SOBOL32>(2);
+    auto tensor = vt::random::rand(10, vt::Order::F, *gen.get());
+
+    float* d_data;
+    auto h_data = std::vector<float>(10);
+    cudaMalloc(&d_data, 10 * sizeof(float));
+
+    curandGenerator_t gen1;
+    curandCreateGenerator(&gen1, CURAND_RNG_QUASI_SCRAMBLED_SOBOL32);
+    curandSetQuasiRandomGeneratorDimensions(gen1, 2);
+    curandGenerateUniform(gen1, d_data, 10);
+    cudaMemcpy(h_data.data(), d_data, 10 * sizeof(float), cudaMemcpyDeviceToHost);
+    auto vec = vt::asvector(tensor);
+    for (size_t i = 0; i < 10; i++) EXPECT_EQ(vec[i], h_data[i]);
+
+    curandDestroyGenerator(gen1);
+    cudaFree(d_data);
+}
+
+TEST(Rand1DC, BasicAssertions) {
     // Set the seed and offset to the original state
     vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
     vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
@@ -56,11 +99,26 @@ TEST(Rand1D, BasicAssertions) {
 
     // Generate from local
     auto gen = vt::cuda::create_curand_handle();
-    auto tensor2 = vt::random::rand(10, *gen.get());
+    auto tensor2 = vt::random::rand(10, vt::Order::C, *gen.get());
     EXPECT_EQ(vt::asvector(tensor1), vt::asvector(tensor2));
 }
 
-TEST(Rand2D, BasicAssertions) {
+TEST(Rand1DF, BasicAssertions) {
+    // Set the seed and offset to the original state
+    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+
+    // Generate from global
+    auto shape = vt::Shape<1>{10};
+    auto tensor1 = vt::random::rand(shape, vt::Order::F);
+
+    // Generate from local
+    auto gen = vt::cuda::create_curand_handle();
+    auto tensor2 = vt::random::rand(10, vt::Order::F, *gen.get());
+    EXPECT_EQ(vt::asvector(tensor1), vt::asvector(tensor2));
+}
+
+TEST(Rand2DC, BasicAssertions) {
     // Set the seed and offset to the original state
     vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
     vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
@@ -71,6 +129,21 @@ TEST(Rand2D, BasicAssertions) {
 
     // Generate from local
     auto gen = vt::cuda::create_curand_handle();
-    auto tensor2 = vt::random::rand(2, 5, *gen.get());
+    auto tensor2 = vt::random::rand(2, 5, vt::Order::C, *gen.get());
+    EXPECT_EQ(vt::asvector(tensor1), vt::asvector(tensor2));
+}
+
+TEST(Rand2DF, BasicAssertions) {
+    // Set the seed and offset to the original state
+    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+
+    // Generate from global
+    auto shape = vt::Shape<1>{10};
+    auto tensor1 = vt::random::rand(shape, vt::Order::F);
+
+    // Generate from local
+    auto gen = vt::cuda::create_curand_handle();
+    auto tensor2 = vt::random::rand(2, 5, vt::Order::F, *gen.get());
     EXPECT_EQ(vt::asvector(tensor1), vt::asvector(tensor2));
 }


### PR DESCRIPTION
- Support F-order tensors operations.
- Hasn't supported mix order operation in this PR.
- Hasn't supported F-order tensor for the linear algebra functions (i.e. matmul, pin).