### PR TITLE
Remove mempool header in vtensor library

### DIFF
--- a/docs/source/api/linalg/cholesky.rst
+++ b/docs/source/api/linalg/cholesky.rst
@@ -4,5 +4,5 @@ vt::linalg::cholesky
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::linalg::cholesky(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cusolver.get_handle())
-.. doxygenfunction:: vt::linalg::cholesky(Tensor<T, N>& tensor, cusolverDnHandle_t handle = cuda::cusolver.get_handle())
+.. doxygenfunction:: vt::linalg::cholesky(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle())
+.. doxygenfunction:: vt::linalg::cholesky(Tensor<T, N>& tensor, cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle())

--- a/docs/source/api/linalg/cublas.rst
+++ b/docs/source/api/linalg/cublas.rst
@@ -14,8 +14,6 @@ vt::cuda::CuBLAS
 .. doxygenclass:: vt::cuda::CuBLAS
    :members:
 
-.. doxygenvariable:: vt::cuda::cublas
-
 .. doxygenstruct:: vt::cuda::CuBLASFuncType
    :members:
 

--- a/docs/source/api/linalg/cusolver.rst
+++ b/docs/source/api/linalg/cusolver.rst
@@ -14,8 +14,6 @@ vt::cuda::CuSolver
 .. doxygenclass:: vt::cuda::CuSolver
    :members:
    
-.. doxygenvariable:: vt::cuda::cusolver
-
 .. doxygenstruct:: vt::cuda::CuSolverFuncType
    :members:
 

--- a/docs/source/api/linalg/inv.rst
+++ b/docs/source/api/linalg/inv.rst
@@ -4,5 +4,5 @@ vt::linalg::inv
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::linalg::inv(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cusolver.get_handle())
-.. doxygenfunction:: vt::linalg::inv(Tensor<T, N>& tensor, cublasHandle_t handle = cuda::cublas.get_handle())
+.. doxygenfunction:: vt::linalg::inv(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle())
+.. doxygenfunction:: vt::linalg::inv(Tensor<T, N>& tensor, cublasHandle_t handle = cuda::CuBLAS::get_instance().get_handle())

--- a/docs/source/api/linalg/matmul.rst
+++ b/docs/source/api/linalg/matmul.rst
@@ -4,7 +4,7 @@ vt::matmul
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::matmul(Tensor<T, 1>& tensor1, Tensor<T, 1>& tensor2, cublasHandle_t handle = cuda::cublas.get_handle())
-.. doxygenfunction:: vt::matmul(Tensor<T, 2>& tensor1, Tensor<T, 2>& tensor2, cublasHandle_t handle = cuda::cublas.get_handle())
-.. doxygenfunction:: vt::matmul(Tensor<T, N>& tensor1, Tensor<T, N>& tensor2, cublasHandle_t handle = cuda::cublas.get_handle())
+.. doxygenfunction:: vt::matmul(Tensor<T, 1>& tensor1, Tensor<T, 1>& tensor2, cublasHandle_t handle = cuda::CuBLAS::get_instance().get_handle())
+.. doxygenfunction:: vt::matmul(Tensor<T, 2>& tensor1, Tensor<T, 2>& tensor2, cublasHandle_t handle = cuda::CuBLAS::get_instance().get_handle())
+.. doxygenfunction:: vt::matmul(Tensor<T, N>& tensor1, Tensor<T, N>& tensor2, cublasHandle_t handle = cuda::CuBLAS::get_instance().get_handle())
 

--- a/docs/source/api/linalg/svd.rst
+++ b/docs/source/api/linalg/svd.rst
@@ -4,5 +4,5 @@ vt::linalg::svd
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::linalg::svd(Tensor<T, 2>& tensor, bool full_matrices = true, bool compute_uv = true, cusolverDnHandle_t handle = cuda::cusolver.get_handle())
-.. doxygenfunction:: vt::linalg::svd(Tensor<T, N>& tensor, bool full_matrices = true, bool compute_uv = true, cusolverDnHandle_t handle = cuda::cusolver.get_handle())
+.. doxygenfunction:: vt::linalg::svd(Tensor<T, 2>& tensor, bool full_matrices = true, bool compute_uv = true, cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle())
+.. doxygenfunction:: vt::linalg::svd(Tensor<T, N>& tensor, bool full_matrices = true, bool compute_uv = true, cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle())

--- a/docs/source/api/random/curand.rst
+++ b/docs/source/api/random/curand.rst
@@ -47,7 +47,5 @@ vt::cuda:CuRand
 .. doxygenclass:: vt::cuda::CuRand
    :members:
 
-.. doxygenvariable:: vt::cuda::curand
-
 .. doxygenfunction:: vt::cuda::set_seed(size_t seed, curandGenerator_t gen = curand.get_handle())
 .. doxygenfunction:: vt::cuda::set_offset(size_t offset, curandGenerator_t gen = curand.get_handle())

--- a/docs/source/api/random/normal.rst
+++ b/docs/source/api/random/normal.rst
@@ -4,6 +4,6 @@ vt::normal
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::random::normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
-.. doxygenfunction:: vt::random::normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
-.. doxygenfunction:: vt::random::normal(size_t m, size_t n, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
+.. doxygenfunction:: vt::random::normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::CuRand::get_instance().get_handle())
+.. doxygenfunction:: vt::random::normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::CuRand::get_instance().get_handle())
+.. doxygenfunction:: vt::random::normal(size_t m, size_t n, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::CuRand::get_instance().get_handle())

--- a/docs/source/api/random/rand.rst
+++ b/docs/source/api/random/rand.rst
@@ -4,6 +4,6 @@ vt::rand
 .. toctree::
    :maxdepth: 1
 
-.. doxygenfunction:: vt::random::rand(Shape<N> shape, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
-.. doxygenfunction:: vt::random::rand(size_t m, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
-.. doxygenfunction:: vt::random::rand(size_t m, size_t n, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle())
+.. doxygenfunction:: vt::random::rand(Shape<N> shape, const Order order = Order::C, curandGenerator_t gen = cuda::CuRand::get_instance().get_handle())
+.. doxygenfunction:: vt::random::rand(size_t m, const Order order = Order::C, curandGenerator_t gen = cuda::CuRand::get_instance().get_handle())
+.. doxygenfunction:: vt::random::rand(size_t m, size_t n, const Order order = Order::C, curandGenerator_t gen = cuda::CuRand::get_instance().get_handle())

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,11 +7,9 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 import pathlib
 import sys
-import warnings
-from sphinx.deprecation import RemovedInSphinx90Warning
 
 sys.path.insert(0, pathlib.Path(__file__).parents[2].resolve().as_posix())
-warnings.filterwarnings("ignore", category=RemovedInSphinx90Warning)
+
 project = 'VTensor'
 copyright = '2024, Vorticity Inc'
 author = 'Sheng-Yang Tsui'

--- a/docs/source/tutorials/memory.rst
+++ b/docs/source/tutorials/memory.rst
@@ -1,7 +1,7 @@
 Memory Management
 ==============
 
-VTensor leverages the `RMM device memory pool <https://github.com/rapidsai/rmm>`_ for memory allocation by default, offering two strategies for GPU memory management:
+User could leverage the `RMM device memory pool <https://github.com/rapidsai/rmm>`_ for memory allocation. Here are some ways to manage memory allocation in your program:
 
 1. **Global Memory Pool**: This approach involves configuring the compiler options to set `-DPOOL_SIZE` to a specific percentage of the total GPU memory. An example configuration in a Bazel BUILD file demonstrates this method. Unless altered, this setting reserves 50% of each GPU device's total memory for the global memory pool. Memory allocation logs are saved to `/tmp/vtensor/memory.log`.
 
@@ -11,8 +11,21 @@ VTensor leverages the `RMM device memory pool <https://github.com/rapidsai/rmm>`
        name = "my_program",
        srcs = ["my_program.cc"],
        copts = ["-DPOOL_SIZE=90", "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"],
-       deps = ["@vtensor"],
+       deps = [
+        "//lib:vtensor",
+        "//lib/core:mempool",
+       ],
    )
+
+.. code-block:: cpp
+
+    #include "lib/core/mempool.hpp"
+    #include "lib/vtensor.hpp"
+
+   int main(){
+      // Make sure you include mempool.hpp in your program. A global memory pool is initialized for every GPU device.
+   }
+
 
 2. **Custom Memory Pool**: Alternatively, a custom memory pool can be instantiated by specifying its size and the log file's path. This pool is dedicated to the GPU device in use. 
 
@@ -21,13 +34,16 @@ VTensor leverages the `RMM device memory pool <https://github.com/rapidsai/rmm>`
    cc_binary(
        name = "my_program",
        srcs = ["my_program.cc"],
-       copts = ["-DPOOL_SIZE=90", "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE", "-DDISABLE_GLOBAL_MEMPOOL=true"],
-       deps = ["@vtensor"],
+       copts = ["-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"],
+       deps = [
+        "//lib:vtensor",
+        "//lib/core:rmm_utils",
+    ],
    )
 
 .. code-block:: cpp
 
-   #include <lib/vtensor.hpp>
+   #include "lib/core/rmm_utils.hpp"
 
    int main(){
        auto pool = vt::Mempool(50, "/tmp/vtensor/memory.log"); // Current GPU device's memory pool
@@ -35,8 +51,8 @@ VTensor leverages the `RMM device memory pool <https://github.com/rapidsai/rmm>`
 
 .. code-block:: cpp
 
-   #include <lib/vtensor.hpp>
+   #include "lib/core/rmm_utils.hpp"
 
    int main(){
-       auto pool = vt::GlobalMempool::get_instance(); // Initialize global memory pool for every GPU device
+       auto pool = vt::GlobalMempool(50); // Initialize global memory pool for every GPU device
    }

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -7,6 +7,7 @@ cuda_binary(
     copts = ["-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"],
     deps = [
         "//lib:vtensor",
+        "//lib/core:mempool",
     ]
 )
 
@@ -17,5 +18,6 @@ cuda_binary(
     copts = ["-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"],
     deps = [
         "//lib:vtensor",
+        "//lib/core:mempool",
     ],
 )

--- a/examples/cutensor.cc
+++ b/examples/cutensor.cc
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <lib/core/mempool.hpp>
 #include <lib/vtensor.hpp>
 
 __global__ void kernel1(vt::CuTensor<float, 2> tensor) {

--- a/examples/monte_carlo.cc
+++ b/examples/monte_carlo.cc
@@ -1,6 +1,7 @@
 
 #include <iostream>
 #include <vector>
+#include <lib/core/mempool.hpp>
 #include <lib/vtensor.hpp>
 
 int main() {

--- a/lib/core/BUILD
+++ b/lib/core/BUILD
@@ -9,17 +9,26 @@ cuda_library(
         "broadcast.hpp",
         "cutensor.hpp",
         "iterator.hpp",
-        "mempool.hpp",
         "operator.hpp",
         "print.hpp",
         "slice.hpp",
         "tensor.hpp",
     ],
     deps = [
-        "//lib/core:rmm_libs",
         "@local_cuda//:thrust",
         "@rmm",
     ],
+)
+
+cuda_library(
+    name = "mempool",
+    visibility = ["//visibility:public"],
+    hdrs = ["mempool.hpp"],
+    deps = [
+        ":rmm_libs",
+        "@rmm",
+    ],
+
 )
 
 cc_library(
@@ -43,4 +52,9 @@ cuda_library(
     visibility = ["//visibility:public"],
     hdrs = ["rmm_utils.hpp"],
     deps = ["@rmm"],
+)
+
+exports_files(
+    ["rmm_utils.hpp", "rmm_utils.cc"],
+    visibility = ["//visibility:public"],
 )

--- a/lib/core/mempool.hpp
+++ b/lib/core/mempool.hpp
@@ -4,10 +4,6 @@
 #define POOL_SIZE 50
 #endif
 
-#ifndef DISABLE_GLOBAL_MEMPOOL
-#define DISABLE_GLOBAL_MEMPOOL false
-#endif
-
 #include "lib/core/rmm_utils.hpp"
 
 namespace vt {
@@ -17,11 +13,7 @@ namespace vt {
  */
 class GlobalMempoolInitializer {
    public:
-    GlobalMempoolInitializer() {
-        if (!DISABLE_GLOBAL_MEMPOOL) {
-            GlobalMempool::get_instance(POOL_SIZE);
-        }
-    }
+    GlobalMempoolInitializer() { GlobalMempool::get_instance(POOL_SIZE); }
 };
 
 static GlobalMempoolInitializer mempool_initializer;

--- a/lib/core/tests/BUILD
+++ b/lib/core/tests/BUILD
@@ -15,6 +15,7 @@ cuda_test(
     copts = ["-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"],
     deps = [
         "//lib:vtensor",
+        "//lib/core:mempool",
         "@googletest//:gtest_main",
     ],
 )

--- a/lib/core/tests/test_mempool.cc
+++ b/lib/core/tests/test_mempool.cc
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <lib/vtensor.hpp>
+#include "lib/core/mempool.hpp"
 
 TEST(GlobalMempoolTest, BasicAssertions) {
     vt::GlobalMempool& instance1 = vt::GlobalMempool::get_instance(1);

--- a/lib/linalg/cholesky.hpp
+++ b/lib/linalg/cholesky.hpp
@@ -19,7 +19,7 @@ namespace linalg {
  * @return Tensor: The lower triangle of the Cholesky decomposition.
  */
 template <typename T>
-Tensor<T, 2> cholesky(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+Tensor<T, 2> cholesky(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle()) {
     assert(tensor.order() == vt::Order::C);
     auto [n, m] = tensor.shape();
     assert(n == m);
@@ -52,7 +52,7 @@ Tensor<T, 2> cholesky(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cu
  * @return Tensor: The lower triangle of the Cholesky decomposition.
  */
 template <typename T, size_t N>
-Tensor<T, N> cholesky(Tensor<T, N>& tensor, cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+Tensor<T, N> cholesky(Tensor<T, N>& tensor, cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle()) {
     assert(tensor.order() == vt::Order::C);
     assert_at_least_3d_tensor<N>();
     auto shape = tensor.shape();

--- a/lib/linalg/cublas.hpp
+++ b/lib/linalg/cublas.hpp
@@ -77,9 +77,6 @@ class CuBLAS {
     CuBLASHandleT handle;
 };
 
-// This is global CuBLAS instance
-static CuBLAS& cublas = CuBLAS::get_instance();
-
 /**
  * @brief The type of the CuBLAS functions.
  *

--- a/lib/linalg/cusolver.hpp
+++ b/lib/linalg/cusolver.hpp
@@ -78,9 +78,6 @@ class CuSolver {
     CuSolverHandleT handle;
 };
 
-// This is global CuSolver instance
-static CuSolver& cusolver = CuSolver::get_instance();
-
 /**
  * @brief The type of the CuSolver functions.
  *

--- a/lib/linalg/inv.hpp
+++ b/lib/linalg/inv.hpp
@@ -22,7 +22,7 @@ namespace linalg {
  * @return Tensor: The inverse tensor object.
  */
 template <typename T>
-Tensor<T, 2> inv(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+Tensor<T, 2> inv(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle()) {
     assert(tensor.order() == vt::Order::C);
     auto shape = tensor.shape();
     assert(shape[0] == shape[1]);
@@ -65,7 +65,7 @@ Tensor<T, 2> inv(Tensor<T, 2>& tensor, cusolverDnHandle_t handle = cuda::cusolve
  * @return Tensor<T, N>: The inverse tensor object.
  */
 template <typename T, size_t N>
-Tensor<T, N> inv(Tensor<T, N>& tensor, cublasHandle_t handle = cuda::cublas.get_handle()) {
+Tensor<T, N> inv(Tensor<T, N>& tensor, cublasHandle_t handle = cuda::CuBLAS::get_instance().get_handle()) {
     assert(tensor.order() == vt::Order::C);
     assert_at_least_3d_tensor<N>();
     auto shape = tensor.shape();

--- a/lib/linalg/matmul.hpp
+++ b/lib/linalg/matmul.hpp
@@ -18,7 +18,7 @@ namespace vt {
  * @return Tensor: The result tensor.
  */
 template <typename T>
-Tensor<T, 1> matmul(Tensor<T, 1>& tensor1, Tensor<T, 1>& tensor2, cublasHandle_t handle = cuda::cublas.get_handle()) {
+Tensor<T, 1> matmul(Tensor<T, 1>& tensor1, Tensor<T, 1>& tensor2, cublasHandle_t handle = cuda::CuBLAS::get_instance().get_handle()) {
     assert(tensor1.order() == vt::Order::C);
     assert(tensor2.order() == vt::Order::C);
     assert(tensor1.size() == tensor2.size());
@@ -40,7 +40,7 @@ Tensor<T, 1> matmul(Tensor<T, 1>& tensor1, Tensor<T, 1>& tensor2, cublasHandle_t
  * @return Tensor: The result tensor.
  */
 template <typename T>
-Tensor<T, 2> matmul(Tensor<T, 2>& tensor1, Tensor<T, 2>& tensor2, cublasHandle_t handle = cuda::cublas.get_handle()) {
+Tensor<T, 2> matmul(Tensor<T, 2>& tensor1, Tensor<T, 2>& tensor2, cublasHandle_t handle = cuda::CuBLAS::get_instance().get_handle()) {
     assert(tensor1.order() == vt::Order::C);
     assert(tensor2.order() == vt::Order::C);
     auto shape1 = tensor1.shape();
@@ -75,7 +75,7 @@ Tensor<T, 2> matmul(Tensor<T, 2>& tensor1, Tensor<T, 2>& tensor2, cublasHandle_t
  * @return Tensor: The result tensor.
  */
 template <typename T, size_t N>
-Tensor<T, N> matmul(Tensor<T, N>& tensor1, Tensor<T, N>& tensor2, cublasHandle_t handle = cuda::cublas.get_handle()) {
+Tensor<T, N> matmul(Tensor<T, N>& tensor1, Tensor<T, N>& tensor2, cublasHandle_t handle = cuda::CuBLAS::get_instance().get_handle()) {
     assert(tensor1.order() == vt::Order::C);
     assert(tensor2.order() == vt::Order::C);
     assert_at_least_3d_tensor<N>();

--- a/lib/linalg/svd.hpp
+++ b/lib/linalg/svd.hpp
@@ -26,7 +26,7 @@ namespace linalg {
  */
 template <typename T>
 std::tuple<Tensor<T, 2>, Tensor<T, 1>, Tensor<T, 2>> svd(Tensor<T, 2>& tensor, bool full_matrices = true, bool compute_uv = true,
-                                                         cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+                                                         cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle()) {
     assert(tensor.order() == vt::Order::C);
     auto [n, m] = tensor.shape();
     Tensor<T, 2> x;
@@ -109,7 +109,7 @@ std::tuple<Tensor<T, 2>, Tensor<T, 1>, Tensor<T, 2>> svd(Tensor<T, 2>& tensor, b
  */
 template <typename T, size_t N>
 std::tuple<Tensor<T, N>, Tensor<T, N - 1>, Tensor<T, N>> svd(Tensor<T, N>& tensor, bool full_matrices = true, bool compute_uv = true,
-                                                             cusolverDnHandle_t handle = cuda::cusolver.get_handle()) {
+                                                             cusolverDnHandle_t handle = cuda::CuSolver::get_instance().get_handle()) {
     assert(tensor.order() == vt::Order::C);
     assert_at_least_3d_tensor<N>();
     auto shape = tensor.shape();

--- a/lib/linalg/tests/test_cublas.cc
+++ b/lib/linalg/tests/test_cublas.cc
@@ -4,13 +4,13 @@
 #include <lib/vtensor.hpp>
 
 TEST(GetGlobalCuBLASHandle, BasicAssertions) {
-    auto handle1 = vt::cuda::cublas.get_handle();
-    auto handle2 = vt::cuda::cublas.get_handle();
+    auto handle1 = vt::cuda::CuBLAS::get_instance().get_handle();
+    auto handle2 = vt::cuda::CuBLAS::get_instance().get_handle();
     EXPECT_EQ(handle1, handle2);
 }
 
 TEST(CreateNewCuBLASHandle, BasicAssertions) {
-    auto handle1 = vt::cuda::cublas.get_handle();
+    auto handle1 = vt::cuda::CuBLAS::get_instance().get_handle();
     auto handle2 = vt::cuda::create_cublas_handle();
     EXPECT_NE(handle1, *handle2.get());
 }

--- a/lib/linalg/tests/test_cusolver.cc
+++ b/lib/linalg/tests/test_cusolver.cc
@@ -4,13 +4,13 @@
 #include <lib/vtensor.hpp>
 
 TEST(GetGlobalCuSolverHandle, BasicAssertions) {
-    auto handle1 = vt::cuda::cusolver.get_handle();
-    auto handle2 = vt::cuda::cusolver.get_handle();
+    auto handle1 = vt::cuda::CuSolver::get_instance().get_handle();
+    auto handle2 = vt::cuda::CuSolver::get_instance().get_handle();
     EXPECT_EQ(handle1, handle2);
 }
 
 TEST(CreateNewCuSolverHandle, BasicAssertions) {
-    auto handle1 = vt::cuda::cusolver.get_handle();
+    auto handle1 = vt::cuda::CuSolver::get_instance().get_handle();
     auto handle2 = vt::cuda::create_cusolver_handle();
     EXPECT_NE(handle1, *handle2.get());
 }

--- a/lib/linalg/tests/test_inv.cc
+++ b/lib/linalg/tests/test_inv.cc
@@ -5,8 +5,7 @@
 
 TEST(Inv, BasicAssertions) {
     auto tensor = vt::arange(4).reshape(2, 2);
-
-    auto handle = vt::cuda::cusolver.get_handle();
+    auto handle = vt::cuda::CuSolver::get_instance().get_handle();
     auto re = vt::linalg::inv(tensor, handle);
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 1, 2, 3}));
     EXPECT_EQ(vt::asvector(re), (std::vector<float>{-1.5, 0.5, 1, 0}));

--- a/lib/linalg/tests/test_svd.cc
+++ b/lib/linalg/tests/test_svd.cc
@@ -39,7 +39,7 @@ TEST(SVDFullMatrix2, BasicAssertions) {
     auto [vt, s, u] = vt::linalg::svd(tensor);
 
     auto s1 = vt::asvector(s);
-    std::vector<float> s2 = {2.2409296e+01, 1.9553399e+00, 3.9066444e-07};
+    std::vector<float> s2 = {2.2409298e+01, 1.9553399e+00, 3.9066444e-07};
     for (int i = 0; i < s1.size(); i++) {
         EXPECT_NEAR(s1[i], s2[i], 1e-6);
     }
@@ -104,7 +104,7 @@ TEST(SVDNotFullMatrix2, BasicAssertions) {
     auto [vt, s, u] = vt::linalg::svd(tensor, false);
 
     auto s1 = vt::asvector(s);
-    std::vector<float> s2 = {2.2409296e+01, 1.9553399e+00, 3.9066444e-07};
+    std::vector<float> s2 = {2.2409298e+01, 1.9553399e+00, 3.9066444e-07};
     for (int i = 0; i < s1.size(); i++) {
         EXPECT_NEAR(s1[i], s2[i], 1e-6);
     }

--- a/lib/memory/asfortrantensor.hpp
+++ b/lib/memory/asfortrantensor.hpp
@@ -23,7 +23,7 @@ Tensor<T, 2> asfortrantensor(Tensor<T, 2>& tensor) {
     int m = shape[0];
     int n = shape[1];
     auto result = zeros<T>(shape, Order::F);
-    auto handle = cuda::cublas.get_handle();
+    auto handle = cuda::CuBLAS::get_instance().get_handle();
     auto alpha = T{1.0};
     auto beta = T{0.0};
     auto geam = cuda::CuBLASFunc<T>::geam();

--- a/lib/random/curand.hpp
+++ b/lib/random/curand.hpp
@@ -158,16 +158,13 @@ class CuRand {
     CuRandHandleT handle;
 };
 
-// This is global CuRand instance
-static CuRand& curand = CuRand::get_instance();
-
 /**
  * @brief Set the seed for the pseudo random number generator.
  *
  * @param seed: The seed for the pseudo random number generator.
  * @param gen: The CuRand handle. The default is the global CuRand handle.
  */
-inline void set_seed(size_t seed, curandGenerator_t gen = curand.get_handle()) {
+inline void set_seed(size_t seed, curandGenerator_t gen = CuRand::get_instance().get_handle()) {
     check_curand_status(curandSetPseudoRandomGeneratorSeed(gen, seed), "Failed to set pseudo-random generator seed");
 }
 
@@ -177,7 +174,7 @@ inline void set_seed(size_t seed, curandGenerator_t gen = curand.get_handle()) {
  * @param offset: The offset for the pseudo/quasi random number generator.
  * @param gen: The CuRand handle. The default is the global CuRand handle.
  */
-inline void set_offset(size_t offset, curandGenerator_t gen = curand.get_handle()) {
+inline void set_offset(size_t offset, curandGenerator_t gen = CuRand::get_instance().get_handle()) {
     check_curand_status(curandSetGeneratorOffset(gen, offset), "Failed to set generator offset");
 }
 

--- a/lib/random/normal.hpp
+++ b/lib/random/normal.hpp
@@ -20,7 +20,8 @@ namespace random {
  * @return Tensor<T, N>: The tensor of random numbers.
  */
 template <typename T = float, size_t N>
-Tensor<T, N> normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+Tensor<T, N> normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C,
+                    curandGenerator_t gen = cuda::CuRand::get_instance().get_handle()) {
     auto tensor = Tensor<T, N>(shape, order);
     curandStatus_t status;
     if constexpr (std::is_same<T, float>::value) {
@@ -44,7 +45,8 @@ Tensor<T, N> normal(Shape<N> shape, T mean = T{0.0}, T stddev = T{1.0}, const Or
  * @return Tensor<T, 1>: The tensor of random numbers.
  */
 template <typename T = float>
-Tensor<T, 1> normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+Tensor<T, 1> normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C,
+                    curandGenerator_t gen = cuda::CuRand::get_instance().get_handle()) {
     auto shape = Shape<1>{m};
     return normal<T, 1>(shape, mean, stddev, order, gen);
 }
@@ -62,7 +64,8 @@ Tensor<T, 1> normal(size_t m, T mean = T{0.0}, T stddev = T{1.0}, const Order or
  * @return Tensor<T, 2>: The tensor of random numbers.
  */
 template <typename T = float>
-Tensor<T, 2> normal(size_t m, size_t n, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+Tensor<T, 2> normal(size_t m, size_t n, T mean = T{0.0}, T stddev = T{1.0}, const Order order = Order::C,
+                    curandGenerator_t gen = cuda::CuRand::get_instance().get_handle()) {
     auto shape = Shape<2>{m, n};
     return normal<T, 2>(shape, mean, stddev, order, gen);
 }

--- a/lib/random/rand.hpp
+++ b/lib/random/rand.hpp
@@ -18,7 +18,7 @@ namespace random {
  * @return Tensor<T, N>: The tensor of random numbers.
  */
 template <typename T = float, size_t N>
-Tensor<T, N> rand(Shape<N> shape, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+Tensor<T, N> rand(Shape<N> shape, const Order order = Order::C, curandGenerator_t gen = cuda::CuRand::get_instance().get_handle()) {
     auto tensor = Tensor<T, N>(shape, order);
     curandStatus_t status;
     if constexpr (std::is_same<T, float>::value) {
@@ -40,7 +40,7 @@ Tensor<T, N> rand(Shape<N> shape, const Order order = Order::C, curandGenerator_
  * @return Tensor<T, 1>: The tensor of random numbers.
  */
 template <typename T = float>
-Tensor<T, 1> rand(size_t m, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+Tensor<T, 1> rand(size_t m, const Order order = Order::C, curandGenerator_t gen = cuda::CuRand::get_instance().get_handle()) {
     return rand<T, 1>({m}, order, gen);
 }
 
@@ -55,7 +55,7 @@ Tensor<T, 1> rand(size_t m, const Order order = Order::C, curandGenerator_t gen 
  * @return Tensor<T, 2>: The tensor of random numbers.
  */
 template <typename T = float>
-Tensor<T, 2> rand(size_t m, size_t n, const Order order = Order::C, curandGenerator_t gen = cuda::curand.get_handle()) {
+Tensor<T, 2> rand(size_t m, size_t n, const Order order = Order::C, curandGenerator_t gen = cuda::CuRand::get_instance().get_handle()) {
     return rand<T, 2>({m, n}, order, gen);
 }
 

--- a/lib/random/tests/test_curand.cc
+++ b/lib/random/tests/test_curand.cc
@@ -3,13 +3,13 @@
 #include <lib/vtensor.hpp>
 
 TEST(GetGlobalCuRandHandle, BasicAssertions) {
-    auto handle1 = vt::cuda::curand.get_handle();
-    auto handle2 = vt::cuda::curand.get_handle();
+    auto handle1 = vt::cuda::CuRand::get_instance().get_handle();
+    auto handle2 = vt::cuda::CuRand::get_instance().get_handle();
     EXPECT_EQ(handle1, handle2);
 }
 
 TEST(CreateNewCuRandHandle, BasicAssertions) {
-    auto handle1 = vt::cuda::curand.get_handle();
+    auto handle1 = vt::cuda::CuRand::get_instance().get_handle();
     auto handle2 = vt::cuda::create_curand_handle();
     EXPECT_NE(handle1, *handle2.get());
 }

--- a/lib/random/tests/test_normal.cc
+++ b/lib/random/tests/test_normal.cc
@@ -4,8 +4,8 @@
 
 TEST(NormalC, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     auto shape = vt::Shape<1>{10};
     auto tensor = vt::random::normal(shape);
@@ -27,8 +27,8 @@ TEST(NormalC, BasicAssertions) {
 
 TEST(NormalF, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     auto shape = vt::Shape<1>{10};
     auto tensor = vt::random::normal(shape, 0.0f, 1.0f, vt::Order::F);
@@ -90,8 +90,8 @@ TEST(QusiNormalF, BasicAssertions) {
 
 TEST(Normal1DC, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     // Generate from global
     auto shape = vt::Shape<1>{10};
@@ -105,8 +105,8 @@ TEST(Normal1DC, BasicAssertions) {
 
 TEST(Normal1DF, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     // Generate from global
     auto shape = vt::Shape<1>{10};
@@ -120,8 +120,8 @@ TEST(Normal1DF, BasicAssertions) {
 
 TEST(Normal2DC, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     // Generate from global
     auto shape = vt::Shape<1>{10};
@@ -135,8 +135,8 @@ TEST(Normal2DC, BasicAssertions) {
 
 TEST(Normal2DF, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     // Generate from global
     auto shape = vt::Shape<1>{10};

--- a/lib/random/tests/test_rand.cc
+++ b/lib/random/tests/test_rand.cc
@@ -4,8 +4,8 @@
 
 TEST(RandC, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     auto shape = vt::Shape<1>{10};
     auto tensor = vt::random::rand(shape);
@@ -27,8 +27,8 @@ TEST(RandC, BasicAssertions) {
 
 TEST(RandF, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     auto shape = vt::Shape<1>{10};
     auto tensor = vt::random::rand(shape, vt::Order::F);
@@ -90,8 +90,8 @@ TEST(QusiRandF, BasicAssertions) {
 
 TEST(Rand1DC, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     // Generate from global
     auto shape = vt::Shape<1>{10};
@@ -105,8 +105,8 @@ TEST(Rand1DC, BasicAssertions) {
 
 TEST(Rand1DF, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     // Generate from global
     auto shape = vt::Shape<1>{10};
@@ -120,8 +120,8 @@ TEST(Rand1DF, BasicAssertions) {
 
 TEST(Rand2DC, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     // Generate from global
     auto shape = vt::Shape<1>{10};
@@ -135,8 +135,8 @@ TEST(Rand2DC, BasicAssertions) {
 
 TEST(Rand2DF, BasicAssertions) {
     // Set the seed and offset to the original state
-    vt::cuda::set_seed(0, vt::cuda::curand.get_handle());
-    vt::cuda::set_offset(0, vt::cuda::curand.get_handle());
+    vt::cuda::set_seed(0, vt::cuda::CuRand::get_instance().get_handle());
+    vt::cuda::set_offset(0, vt::cuda::CuRand::get_instance().get_handle());
 
     // Generate from global
     auto shape = vt::Shape<1>{10};

--- a/lib/vtensor.hpp
+++ b/lib/vtensor.hpp
@@ -1,6 +1,5 @@
 #include "lib/core/broadcast.hpp"
 #include "lib/core/cutensor.hpp"
-#include "lib/core/mempool.hpp"
 #include "lib/core/operator.hpp"
 #include "lib/core/print.hpp"
 #include "lib/core/slice.hpp"


### PR DESCRIPTION
Remove the `mempool.hpp` in `lib/vtensor.hpp`. Users could decide whether they want to have a memory pool in their program. This PR would also resolve multi processing issue (remove `static` variable for mempool, cublas, cusolver etc.)