### PR TITLE
[VTEN-19] Add-broadcast-to-tensor-assignment

### DIFF
--- a/docs/source/api/core/proxy_slice.rst
+++ b/docs/source/api/core/proxy_slice.rst
@@ -10,6 +10,9 @@ vt::TensorSliceProxy
 .. doxygenstruct:: vt::NewAxisT
    :members:
 
+.. doxygenenum:: vt::SliceType
+   :members:
+
 .. doxygenclass:: vt::Slice
    :members:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,8 @@ Comparison between NumPy and VTensor
      - vt::expand_dims_lhs<T, N, 2>(tensor)
    * - arr[..., None, None]
      - vt::expand_dims_rhs<T, N, 2>(tensor)
+   * - arr[:, :]
+     - tensor(vt::Slice::all(), vt::Slice::all())
 
 .. list-table:: Broadcasting
    :header-rows: 1

--- a/lib/core/tests/test_slice.cc
+++ b/lib/core/tests/test_slice.cc
@@ -136,3 +136,17 @@ TEST(TensorCondProxyFromConstantF, BasicAssertions) {
     tensor[tensor > 12.0f] = 1.0f;
     EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{0, 2, 4, 6, 8, 10, 12, 1, 1, 1, 1, 1}));
 }
+
+TEST(BroadcastSliceAssignmentC, BasicAssertions) {
+    auto tensor = vt::arange(12).reshape(4, 3);
+    tensor(vt::Slice::all(), vt::Slice(0, 2, 1)) = tensor(vt::Slice::all(), vt::Slice(2, 3, 1));
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{2, 2, 2, 5, 5, 5, 8, 8, 8, 11, 11, 11}));
+    EXPECT_EQ(tensor.contiguous(), true);
+}
+
+TEST(BroadcastSliceAssignmentF, BasicAssertions) {
+    auto tensor = vt::arange(12, vt::Order::F).reshape(4, 3);
+    tensor(vt::Slice::all(), vt::Slice(0, 2, 1)) = tensor(vt::Slice::all(), vt::Slice(2, 3, 1));
+    EXPECT_EQ(vt::asvector(tensor), (std::vector<float>{8, 9, 10, 11, 8, 9, 10, 11, 8, 9, 10, 11}));
+    EXPECT_EQ(tensor.contiguous(), true);
+}


### PR DESCRIPTION
1. Add broadcast assignment for tensor
2. Add a slice method to represent full range.
```
    auto tensor = vt::arange(12).reshape(4, 3);
    tensor(vt::Slice::all(), vt::Slice(0, 2, 1)) = tensor(vt::Slice::all(), vt::Slice(2, 3, 1));
```